### PR TITLE
Fix Next.js build dependencies and dev Docker Compose setup

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,20 +1,29 @@
 # syntax=docker/dockerfile:1
-FROM node:20-alpine AS base
+FROM node:20-alpine AS deps
 WORKDIR /app
 
-# Install dependencies
 COPY package*.json ./
 RUN npm install
 
-# Copy application files
+FROM deps AS builder
 COPY . .
-
-# Build Next.js application
 RUN npm run build
 
-EXPOSE 3000
-
-ENV PORT=3000
+FROM deps AS dev
+ENV NODE_ENV=development
 ENV NEXT_TELEMETRY_DISABLED=1
+COPY . .
+CMD ["npm", "run", "dev"]
+
+FROM node:20-alpine AS production
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+
+COPY --from=builder /app .
+
+EXPOSE 3000
 
 CMD ["npm", "run", "start"]

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         "@heroui/react": "^2.8.2",
         "@heroui/system": "^2.4.20",
         "@heroui/theme": "^2.4.20",
-        "@internationalized/date": "^3.8.2",
+        "@internationalized/date": "3.9.0",
         "@react-aria/ssr": "3.9.10",
         "@react-aria/visually-hidden": "3.8.26",
         "axios": "^1.6.0",
@@ -29,6 +29,7 @@
         "react-hot-toast": "^2.4.1"
       },
       "devDependencies": {
+        "@eslint/compat": "1.4.0",
         "@next/eslint-plugin-next": "15.5.4",
         "@react-types/shared": "3.30.0",
         "@tailwindcss/postcss": "4.1.11",
@@ -151,6 +152,40 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.0.tgz",
+      "integrity": "sha512-DEzm5dKeDBPm3r08Ixli/0cmxr8LkRdwxMRUIJBlSCpAwSrvFEJpVBzV+66JhDxiaqKxnRzCXhtiMiczF7Hglg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.16.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.40 || 9"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/compat/node_modules/@eslint/core": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-array": {
@@ -617,15 +652,6 @@
         "react-dom": ">=18 || >=19.0.0-rc.0"
       }
     },
-    "node_modules/@heroui/calendar/node_modules/@internationalized/date": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.9.0.tgz",
-      "integrity": "sha512-yaN3brAnHRD+4KyyOsJyk49XUvj2wtbNACSqg0bz3u8t2VuzhC8Q5dfRnrSxjnnbDb+ienBnkn1TzQfE154vyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
     "node_modules/@heroui/calendar/node_modules/@react-aria/visually-hidden": {
       "version": "3.8.27",
       "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.27.tgz",
@@ -775,15 +801,6 @@
         "react-dom": ">=18 || >=19.0.0-rc.0"
       }
     },
-    "node_modules/@heroui/date-input/node_modules/@internationalized/date": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.9.0.tgz",
-      "integrity": "sha512-yaN3brAnHRD+4KyyOsJyk49XUvj2wtbNACSqg0bz3u8t2VuzhC8Q5dfRnrSxjnnbDb+ienBnkn1TzQfE154vyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
     "node_modules/@heroui/date-input/node_modules/@react-types/shared": {
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.32.0.tgz",
@@ -822,15 +839,6 @@
         "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
         "react": ">=18 || >=19.0.0-rc.0",
         "react-dom": ">=18 || >=19.0.0-rc.0"
-      }
-    },
-    "node_modules/@heroui/date-picker/node_modules/@internationalized/date": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.9.0.tgz",
-      "integrity": "sha512-yaN3brAnHRD+4KyyOsJyk49XUvj2wtbNACSqg0bz3u8t2VuzhC8Q5dfRnrSxjnnbDb+ienBnkn1TzQfE154vyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@heroui/date-picker/node_modules/@react-types/shared": {
@@ -2792,9 +2800,9 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.10.0.tgz",
-      "integrity": "sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.9.0.tgz",
+      "integrity": "sha512-yaN3brAnHRD+4KyyOsJyk49XUvj2wtbNACSqg0bz3u8t2VuzhC8Q5dfRnrSxjnnbDb+ienBnkn1TzQfE154vyg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -3394,6 +3402,15 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@internationalized/date": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.10.0.tgz",
+      "integrity": "sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@react-aria/grid/node_modules/@react-aria/focus": {
@@ -4048,6 +4065,15 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@internationalized/date": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.10.0.tgz",
+      "integrity": "sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@react-aria/spinbutton/node_modules/@react-aria/i18n": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "@heroui/react": "^2.8.2",
     "@heroui/system": "^2.4.20",
     "@heroui/theme": "^2.4.20",
-    "@internationalized/date": "^3.8.2",
+    "@internationalized/date": "3.9.0",
     "@react-aria/ssr": "3.9.10",
     "@react-aria/visually-hidden": "3.8.26",
     "axios": "^1.6.0",
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "15.5.4",
+    "@eslint/compat": "1.4.0",
     "@react-types/shared": "3.30.0",
     "@tailwindcss/postcss": "4.1.11",
     "@types/node": "20.5.7",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,18 @@ services:
   client:
     build:
       context: ./client
+      target: dev
     env_file:
       - ./client/.env.local
     environment:
+      NODE_ENV: development
       NEXT_PUBLIC_API_URL: '${NEXT_PUBLIC_API_URL:-http://localhost:3000/api}'
+      NEXT_TELEMETRY_DISABLED: '1'
     ports:
       - "3001:3000"
+    volumes:
+      - ./client:/app
+      - /app/node_modules
+    command: npm run dev
     depends_on:
       - server


### PR DESCRIPTION
## Summary
- add the missing @eslint/compat dev dependency and pin @internationalized/date to 3.9.0 to resolve Next.js build type errors
- refactor the client Dockerfile into multi-stage builds for development and production flows
- configure docker-compose to target the development stage with hot-reload-friendly settings

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dfb34b581c832288149932ae616c4d