### PR TITLE
Improve dashboard accessibility and translations

### DIFF
--- a/client/app/dashboard/layout.tsx
+++ b/client/app/dashboard/layout.tsx
@@ -1,26 +1,56 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
-  Button, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem,
-  Avatar, Badge, Chip, Input, Kbd, Link
-} from '@heroui/react';
-import { useAuth } from '@/contexts/AuthContext';
-import { useRouter, usePathname } from 'next/navigation';
-import NextLink from 'next/link';
-import CommandPalette from '@/components/CommandPalette';
+  Button,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+  Avatar,
+  Chip,
+  Input,
+  Kbd,
+} from "@heroui/react";
+import { useRouter, usePathname } from "next/navigation";
+import NextLink from "next/link";
+import {
+  Building2,
+  Users,
+  Calendar,
+  Stethoscope,
+  Bed,
+  Settings,
+  Bell,
+  Search,
+  Home,
+  FileText,
+  Package,
+  Sun,
+  Moon,
+  Monitor,
+  User,
+  LogOut,
+  ClipboardList,
+  Pill,
+  Heart,
+  UserCheck,
+  Shield,
+  Clock,
+  MessageSquare,
+  Star,
+  Zap,
+  Scissors,
+  BarChart3,
+  Database,
+  TestTube,
+} from "lucide-react";
+import { useTheme } from "next-themes";
 
-import {
-  Building2, Users, Calendar, Check, Stethoscope,
-  Bed, DollarSign, Activity, Settings, Bell, Search,
-  Home, FileText, Package, Sun, Moon, Monitor, User, LogOut,
-  ClipboardList, Pill, Heart, UserCheck, Shield, Clock,
-  MessageSquare, Star, Clipboard, Zap, Briefcase,
-  Scissors, Navigation, BarChart3, Database, TestTube
-} from 'lucide-react';
-import { useTheme } from 'next-themes';
-import { useI18n } from '@/contexts/I18nContext';
-import { dashboardAPI } from '@/lib/api';
+import CommandPalette from "@/components/CommandPalette";
+import { useAuth } from "@/contexts/AuthContext";
+import { useI18n } from "@/contexts/I18nContext";
+import { dashboardAPI } from "@/lib/api";
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -55,67 +85,188 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     {
       name: "Overview",
       items: [
-        { icon: <Home size={20} />, label: t('navigation.dashboard') || 'Dashboard', href: '/dashboard' },
-      ]
+        {
+          icon: <Home size={20} />,
+          label: t("navigation.dashboard") || "Dashboard",
+          href: "/dashboard",
+        },
+      ],
     },
     {
       name: "Patient Care",
       items: [
-        { icon: <Users size={20} />, label: t('navigation.patients') || 'Patients', href: '/dashboard/patients', requiredPermission: 1 },
-        { icon: <Calendar size={20} />, label: t('navigation.appointments') || 'Appointments', href: '/dashboard/appointments', requiredPermission: 1 },
-        { icon: <ClipboardList size={20} />, label: 'Visits', href: '/dashboard/visits', requiredPermission: 1 },
-        { icon: <FileText size={20} />, label: t('navigation.medical_records') || 'Medical Records', href: '/dashboard/medical-records', requiredPermission: 1 },
-      ]
+        {
+          icon: <Users size={20} />,
+          label: t("navigation.patients") || "Patients",
+          href: "/dashboard/patients",
+          requiredPermission: 1,
+        },
+        {
+          icon: <Calendar size={20} />,
+          label: t("navigation.appointments") || "Appointments",
+          href: "/dashboard/appointments",
+          requiredPermission: 1,
+        },
+        {
+          icon: <ClipboardList size={20} />,
+          label: "Visits",
+          href: "/dashboard/visits",
+          requiredPermission: 1,
+        },
+        {
+          icon: <FileText size={20} />,
+          label: t("navigation.medical_records") || "Medical Records",
+          href: "/dashboard/medical-records",
+          requiredPermission: 1,
+        },
+      ],
     },
     {
       name: "Medical Operations",
       items: [
-        { icon: <TestTube size={20} />, label: t('navigation.tests') || 'Tests & Labs', href: '/dashboard/tests', requiredPermission: 1 },
-        { icon: <Heart size={20} />, label: 'Treatments', href: '/dashboard/treatments', requiredPermission: 1 },
-        { icon: <Pill size={20} />, label: 'Prescriptions', href: '/dashboard/prescriptions', requiredPermission: 1 },
-        { icon: <Scissors size={20} />, label: 'Surgeries', href: '/dashboard/surgeries', requiredPermission: 2 },
-      ]
+        {
+          icon: <TestTube size={20} />,
+          label: t("navigation.tests") || "Tests & Labs",
+          href: "/dashboard/tests",
+          requiredPermission: 1,
+        },
+        {
+          icon: <Heart size={20} />,
+          label: "Treatments",
+          href: "/dashboard/treatments",
+          requiredPermission: 1,
+        },
+        {
+          icon: <Pill size={20} />,
+          label: "Prescriptions",
+          href: "/dashboard/prescriptions",
+          requiredPermission: 1,
+        },
+        {
+          icon: <Scissors size={20} />,
+          label: "Surgeries",
+          href: "/dashboard/surgeries",
+          requiredPermission: 2,
+        },
+      ],
     },
     {
       name: "Hospital Management",
       items: [
-        { icon: <Stethoscope size={20} />, label: t('navigation.staff') || 'Staff', href: '/dashboard/staff', requiredPermission: 3 },
-        { icon: <Building2 size={20} />, label: t('navigation.departments') || 'Departments', href: '/dashboard/departments', requiredPermission: 2 },
-        { icon: <Bed size={20} />, label: t('navigation.rooms') || 'Rooms', href: '/dashboard/rooms', requiredPermission: 2 },
-        { icon: <Clock size={20} />, label: 'Shifts', href: '/dashboard/shifts', requiredPermission: 2 },
-        { icon: <UserCheck size={20} />, label: 'Surgery Teams', href: '/dashboard/surgery-teams', requiredPermission: 2 },
-      ]
+        {
+          icon: <Stethoscope size={20} />,
+          label: t("navigation.staff") || "Staff",
+          href: "/dashboard/staff",
+          requiredPermission: 3,
+        },
+        {
+          icon: <Building2 size={20} />,
+          label: t("navigation.departments") || "Departments",
+          href: "/dashboard/departments",
+          requiredPermission: 2,
+        },
+        {
+          icon: <Bed size={20} />,
+          label: t("navigation.rooms") || "Rooms",
+          href: "/dashboard/rooms",
+          requiredPermission: 2,
+        },
+        {
+          icon: <Clock size={20} />,
+          label: "Shifts",
+          href: "/dashboard/shifts",
+          requiredPermission: 2,
+        },
+        {
+          icon: <UserCheck size={20} />,
+          label: "Surgery Teams",
+          href: "/dashboard/surgery-teams",
+          requiredPermission: 2,
+        },
+      ],
     },
     {
       name: "Inventory",
       items: [
-        { icon: <Package size={20} />, label: 'Medications', href: '/dashboard/medications', requiredPermission: 2 },
-        { icon: <Zap size={20} />, label: 'Equipment', href: '/dashboard/equipment', requiredPermission: 2 },
-      ]
+        {
+          icon: <Package size={20} />,
+          label: "Medications",
+          href: "/dashboard/medications",
+          requiredPermission: 2,
+        },
+        {
+          icon: <Zap size={20} />,
+          label: "Equipment",
+          href: "/dashboard/equipment",
+          requiredPermission: 2,
+        },
+      ],
     },
     {
       name: "Communication",
       items: [
-        { icon: <Bell size={20} />, label: t('navigation.alerts') || 'Notifications', href: '/dashboard/alerts', requiredPermission: 1, badge: alertCount > 0 ? alertCount : undefined },
-        { icon: <MessageSquare size={20} />, label: 'Complaints', href: '/dashboard/complaints', requiredPermission: 1 },
-        { icon: <Star size={20} />, label: 'Feedback', href: '/dashboard/feedback', requiredPermission: 1 },
-      ]
+        {
+          icon: <Bell size={20} />,
+          label: t("navigation.alerts") || "Notifications",
+          href: "/dashboard/alerts",
+          requiredPermission: 1,
+          badge: alertCount > 0 ? alertCount : undefined,
+        },
+        {
+          icon: <MessageSquare size={20} />,
+          label: "Complaints",
+          href: "/dashboard/complaints",
+          requiredPermission: 1,
+        },
+        {
+          icon: <Star size={20} />,
+          label: "Feedback",
+          href: "/dashboard/feedback",
+          requiredPermission: 1,
+        },
+      ],
     },
     {
       name: "Administration",
       items: [
-        { icon: <Shield size={20} />, label: 'Insurance', href: '/dashboard/insurance', requiredPermission: 2 },
-        { icon: <Building2 size={20} />, label: 'Hospital Info', href: '/dashboard/hospital', requiredPermission: 3 },
-        { icon: <BarChart3 size={20} />, label: 'Analytics', href: '/dashboard/analytics', requiredPermission: 2 },
-        { icon: <Database size={20} />, label: 'Reports', href: '/dashboard/reports', requiredPermission: 2 },
-        { icon: <Settings size={20} />, label: t('navigation.settings') || 'Settings', href: '/dashboard/settings', requiredPermission: 1 },
-      ]
-    }
+        {
+          icon: <Shield size={20} />,
+          label: "Insurance",
+          href: "/dashboard/insurance",
+          requiredPermission: 2,
+        },
+        {
+          icon: <Building2 size={20} />,
+          label: "Hospital Info",
+          href: "/dashboard/hospital",
+          requiredPermission: 3,
+        },
+        {
+          icon: <BarChart3 size={20} />,
+          label: "Analytics",
+          href: "/dashboard/analytics",
+          requiredPermission: 2,
+        },
+        {
+          icon: <Database size={20} />,
+          label: "Reports",
+          href: "/dashboard/reports",
+          requiredPermission: 2,
+        },
+        {
+          icon: <Settings size={20} />,
+          label: t("navigation.settings") || "Settings",
+          href: "/dashboard/settings",
+          requiredPermission: 1,
+        },
+      ],
+    },
   ];
 
   useEffect(() => {
     const checkScreenSize = () => {
       const mobile = window.innerWidth < 1024;
+
       setIsMobile(mobile);
       if (!mobile) {
         setSidebarOpen(false);
@@ -123,8 +274,9 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     };
 
     checkScreenSize();
-    window.addEventListener('resize', checkScreenSize);
-    return () => window.removeEventListener('resize', checkScreenSize);
+    window.addEventListener("resize", checkScreenSize);
+
+    return () => window.removeEventListener("resize", checkScreenSize);
   }, []);
 
   // Load alert count
@@ -132,10 +284,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     const loadAlertCount = async () => {
       try {
         const response = await dashboardAPI.getAlerts();
-        const unreadAlerts = response.data.alerts?.filter((alert: any) => !alert.isRead) || [];
+        const unreadAlerts =
+          response.data.alerts?.filter((alert: any) => !alert.isRead) || [];
+
         setAlertCount(unreadAlerts.length);
       } catch (error) {
-        console.error('Error loading alert count:', error);
+        console.error("Error loading alert count:", error);
         setAlertCount(0);
       }
     };
@@ -144,6 +298,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       loadAlertCount();
       // Refresh alert count every 30 seconds
       const interval = setInterval(loadAlertCount, 30000);
+
       return () => clearInterval(interval);
     }
   }, [user]);
@@ -152,50 +307,60 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Ctrl+K or Cmd+K to open command palette
-      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+      if ((e.ctrlKey || e.metaKey) && e.key === "k") {
         e.preventDefault();
         setCommandPaletteOpen(true);
       }
       // Escape to close command palette
-      if (e.key === 'Escape' && commandPaletteOpen) {
+      if (e.key === "Escape" && commandPaletteOpen) {
         setCommandPaletteOpen(false);
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [commandPaletteOpen]);
 
   const handleLogout = () => {
     logout();
-    router.push('/');
+    router.push("/");
   };
 
   const hasPermission = (requiredLevel?: number) => {
     if (!requiredLevel || !user) return true;
+
     return user.permLevel >= requiredLevel;
   };
 
-  const filteredMenuCategories = menuCategories.map(category => ({
-    ...category,
-    items: category.items.filter(item => hasPermission(item.requiredPermission))
-  })).filter(category => category.items.length > 0);
+  const filteredMenuCategories = menuCategories
+    .map((category) => ({
+      ...category,
+      items: category.items.filter((item) =>
+        hasPermission(item.requiredPermission),
+      ),
+    }))
+    .filter((category) => category.items.length > 0);
 
   const getUserRole = () => {
-    if (!user) return t('user.guest');
+    if (!user) return t("user.guest");
     switch (user.permLevel) {
-      case 3: return t('user.admin');
-      case 2: return t('user.doctor');
-      case 1: return t('user.nurse');
-      default: return t('user.user');
+      case 3:
+        return t("user.admin");
+      case 2:
+        return t("user.doctor");
+      case 1:
+        return t("user.nurse");
+      default:
+        return t("user.user");
     }
   };
 
   const getThemeIcon = () => {
     switch (theme) {
-      case 'light':
+      case "light":
         return <Sun className="h-4 w-4" />;
-      case 'dark':
+      case "dark":
         return <Moon className="h-4 w-4" />;
       default:
         return <Monitor className="h-4 w-4" />;
@@ -203,12 +368,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   };
 
   const cycleTheme = () => {
-    if (theme === 'light') {
-      setTheme('dark');
-    } else if (theme === 'dark') {
-      setTheme('system');
+    if (theme === "light") {
+      setTheme("dark");
+    } else if (theme === "dark") {
+      setTheme("system");
     } else {
-      setTheme('light');
+      setTheme("light");
     }
   };
 
@@ -216,13 +381,15 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     <div className="min-h-screen bg-background">
       <div className="flex h-screen">
         {/* Enhanced Sidebar with Navbar Features */}
-        <aside className={`
+        <aside
+          className={`
           fixed inset-y-0 left-0 z-40 w-80 transform transition-all duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0
-          ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
-          ${isMobile ? 'top-16' : 'top-0'}
+          ${sidebarOpen ? "translate-x-0" : "-translate-x-full"}
+          ${isMobile ? "top-16" : "top-0"}
           bg-background/95 backdrop-blur-md supports-[backdrop-filter]:bg-background/95
           border-r border-divider shadow-lg lg:shadow-none
-        `}>
+        `}
+        >
           <nav className="flex h-full flex-col overflow-hidden">
             {/* Enhanced Sidebar Header with Branding */}
             <div className="p-6 border-b border-divider bg-gradient-to-r from-primary/5 to-primary/10">
@@ -232,40 +399,41 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                 </div>
                 <div>
                   <h1 className="font-bold text-lg text-foreground">MedCare</h1>
-                  <p className="text-xs text-muted-foreground">Hospital Management</p>
+                  <p className="text-xs text-muted-foreground">
+                    Hospital Management
+                  </p>
                 </div>
               </div>
-              
+
               {/* Search Bar */}
               <div className="relative">
                 <Input
-                  placeholder="Search patients, appointments..."
-                  startContent={<Search className="text-muted-foreground" size={18} />}
+                  readOnly
+                  classNames={{
+                    inputWrapper:
+                      "bg-background/50 border-divider hover:bg-background/80 transition-colors cursor-pointer",
+                    input: "text-sm cursor-pointer",
+                  }}
                   endContent={
                     <Kbd className="hidden sm:inline-block" keys={["command"]}>
                       K
                     </Kbd>
                   }
-                  classNames={{
-                    inputWrapper: "bg-background/50 border-divider hover:bg-background/80 transition-colors cursor-pointer",
-                    input: "text-sm cursor-pointer"
-                  }}
+                  placeholder="Search patients, appointments..."
                   size="sm"
-                  readOnly
+                  startContent={
+                    <Search className="text-muted-foreground" size={18} />
+                  }
                   onClick={() => setCommandPaletteOpen(true)}
                 />
               </div>
             </div>
 
-
-
             {/* Navigation Items */}
-            <div className="flex-1 overflow-y-auto px-4 py-4" style={{scrollbarWidth: 'none', msOverflowStyle: 'none'}}>
-              <style jsx>{`
-                div::-webkit-scrollbar {
-                  display: none;
-                }
-              `}</style>
+            <div
+              className="flex-1 overflow-y-auto px-4 py-4"
+              style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+            >
               <div className="space-y-6">
                 {filteredMenuCategories.map((category, categoryIndex) => (
                   <div key={category.name} className="space-y-2">
@@ -275,48 +443,52 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                         {category.name}
                       </h3>
                     </div>
-                    
+
                     {/* Category Items */}
                     <div className="space-y-1">
                       {category.items.map((item, index) => {
                         const isActive = pathname === item.href;
+
                         return (
                           <NextLink
                             key={item.href}
-                            href={item.href}
-                            onClick={() => isMobile && setSidebarOpen(false)}
                             className={`
                               group relative flex items-center space-x-3 rounded-xl px-3 py-3 text-sm font-medium transition-colors duration-200 ease-in-out
-                              ${isActive
-                                ? 'bg-gradient-to-r from-primary/20 to-primary/10 text-primary border border-primary/20 shadow-sm'
-                                : 'text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground'
+                              ${
+                                isActive
+                                  ? "bg-gradient-to-r from-primary/20 to-primary/10 text-primary border border-primary/20 shadow-sm"
+                                  : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground"
                               }
                             `}
+                            href={item.href}
+                            onClick={() => isMobile && setSidebarOpen(false)}
                           >
                             {/* Active indicator */}
                             {isActive && (
                               <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-primary rounded-r-full shadow-lg" />
                             )}
-                            
+
                             {/* Icon */}
-                            <div className={`
+                            <div
+                              className={`
                               flex-shrink-0 transition-colors duration-200 ease-out
-                              ${isActive ? 'text-primary' : 'text-muted-foreground group-hover:text-accent-foreground'}
-                            `}>
+                              ${isActive ? "text-primary" : "text-muted-foreground group-hover:text-accent-foreground"}
+                            `}
+                            >
                               {item.icon}
                             </div>
-                            
+
                             {/* Label */}
                             <span className="flex-1 truncate transition-colors duration-200">
                               {item.label}
                             </span>
-                            
+
                             {/* Badge */}
                             {item.badge && (
-                              <Chip 
-                                size="sm" 
-                                color="danger" 
+                              <Chip
                                 className="ml-auto animate-pulse-slow"
+                                color="danger"
+                                size="sm"
                                 variant="flat"
                               >
                                 {item.badge}
@@ -330,20 +502,20 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                 ))}
               </div>
             </div>
-            
+
             {/* User Profile Section at Bottom */}
             <div className="p-4 border-t border-divider">
               <Dropdown placement="top-start">
                 <DropdownTrigger>
-                  <Button 
-                    variant="ghost" 
+                  <Button
                     className="w-full justify-start p-3 h-auto hover:bg-accent/50 transition-colors group"
+                    variant="ghost"
                   >
                     <div className="flex items-center space-x-3 w-full">
                       <Avatar
+                        className="ring-2 ring-primary/20"
                         name={user?.username}
                         size="sm"
-                        className="ring-2 ring-primary/20"
                       />
                       <div className="flex-1 text-left">
                         <p className="text-sm font-medium text-foreground group-hover:text-primary transition-colors">
@@ -357,12 +529,19 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                   </Button>
                 </DropdownTrigger>
                 <DropdownMenu aria-label="User menu">
-                  <DropdownItem key="profile" isReadOnly isDisabled className="opacity-100">
+                  <DropdownItem
+                    key="profile"
+                    isDisabled
+                    isReadOnly
+                    className="opacity-100"
+                  >
                     <div className="flex items-center space-x-2">
                       <User className="h-4 w-4" />
                       <div className="flex flex-col">
                         <p className="text-sm font-medium">{user?.username}</p>
-                        <p className="text-xs text-muted-foreground">{getUserRole()}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {getUserRole()}
+                        </p>
                       </div>
                     </div>
                   </DropdownItem>
@@ -370,21 +549,31 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                     <div className="flex items-center space-x-2">
                       {getThemeIcon()}
                       <span>
-                        {theme === 'light' ? t('theme.light') : 
-                         theme === 'dark' ? t('theme.dark') : t('theme.system')}
+                        {theme === "light"
+                          ? t("theme.light")
+                          : theme === "dark"
+                            ? t("theme.dark")
+                            : t("theme.system")}
                       </span>
                     </div>
                   </DropdownItem>
-                  <DropdownItem key="settings" onPress={() => router.push('/dashboard/settings')}>
+                  <DropdownItem
+                    key="settings"
+                    onPress={() => router.push("/dashboard/settings")}
+                  >
                     <div className="flex items-center space-x-2">
                       <Settings className="h-4 w-4" />
-                      <span>{t('navigation.settings')}</span>
+                      <span>{t("navigation.settings")}</span>
                     </div>
                   </DropdownItem>
-                  <DropdownItem key="logout" color="danger" onPress={handleLogout}>
+                  <DropdownItem
+                    key="logout"
+                    color="danger"
+                    onPress={handleLogout}
+                  >
                     <div className="flex items-center space-x-2">
                       <LogOut className="h-4 w-4" />
-                      <span>{t('auth.logout')}</span>
+                      <span>{t("auth.logout")}</span>
                     </div>
                   </DropdownItem>
                 </DropdownMenu>
@@ -398,15 +587,28 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           <div
             className={`
               fixed inset-0 z-30 transition-all duration-300 ease-in-out lg:hidden
-              ${sidebarOpen 
-                ? 'bg-black/60 backdrop-blur-sm opacity-100 visible' 
-                : 'bg-black/0 backdrop-blur-0 opacity-0 invisible'
+              ${
+                sidebarOpen
+                  ? "bg-black/60 backdrop-blur-sm opacity-100 visible"
+                  : "bg-black/0 backdrop-blur-0 opacity-0 invisible"
               }
             `}
-            onClick={() => setSidebarOpen(false)}
             style={{
-              WebkitBackdropFilter: sidebarOpen ? 'blur(4px)' : 'blur(0px)',
-              backdropFilter: sidebarOpen ? 'blur(4px)' : 'blur(0px)',
+              WebkitBackdropFilter: sidebarOpen ? "blur(4px)" : "blur(0px)",
+              backdropFilter: sidebarOpen ? "blur(4px)" : "blur(0px)",
+            }}
+            aria-label="Close sidebar overlay"
+            role="button"
+            tabIndex={0}
+            onClick={() => setSidebarOpen(false)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                setSidebarOpen(false);
+              }
+              if (event.key === "Escape") {
+                setSidebarOpen(false);
+              }
             }}
           />
         )}
@@ -417,49 +619,47 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           {isMobile && (
             <Button
               isIconOnly
-              variant="ghost"
               className="fixed top-4 left-4 z-50 lg:hidden bg-background/80 backdrop-blur-sm shadow-md"
+              variant="ghost"
               onPress={() => setSidebarOpen(!sidebarOpen)}
             >
               <div className="relative w-6 h-6 flex items-center justify-center">
                 <div className="flex flex-col space-y-1.5 transition-all duration-300 ease-in-out">
-                  <span 
+                  <span
                     className={`
                       block w-5 h-0.5 bg-current transition-all duration-300 ease-in-out origin-center
-                      ${sidebarOpen ? 'rotate-45 translate-y-2' : 'rotate-0 translate-y-0'}
-                    `} 
+                      ${sidebarOpen ? "rotate-45 translate-y-2" : "rotate-0 translate-y-0"}
+                    `}
                   />
-                  <span 
+                  <span
                     className={`
                       block w-5 h-0.5 bg-current transition-all duration-300 ease-in-out
-                      ${sidebarOpen ? 'opacity-0 scale-0' : 'opacity-100 scale-100'}
-                    `} 
+                      ${sidebarOpen ? "opacity-0 scale-0" : "opacity-100 scale-100"}
+                    `}
                   />
-                  <span 
+                  <span
                     className={`
                       block w-5 h-0.5 bg-current transition-all duration-300 ease-in-out origin-center
-                      ${sidebarOpen ? '-rotate-45 -translate-y-2' : 'rotate-0 translate-y-0'}
-                    `} 
+                      ${sidebarOpen ? "-rotate-45 -translate-y-2" : "rotate-0 translate-y-0"}
+                    `}
                   />
                 </div>
               </div>
             </Button>
           )}
-          
-          <div className="container mx-auto p-4 sm:p-6">
-            {children}
-          </div>
+
+          <div className="container mx-auto p-4 sm:p-6">{children}</div>
         </main>
       </div>
 
       {/* Command Palette */}
       <CommandPalette
         isOpen={commandPaletteOpen}
-        onClose={() => setCommandPaletteOpen(false)}
+        theme={theme}
         user={user}
+        onClose={() => setCommandPaletteOpen(false)}
         onLogout={handleLogout}
         onThemeChange={cycleTheme}
-        theme={theme}
       />
     </div>
   );

--- a/client/app/dashboard/page.tsx
+++ b/client/app/dashboard/page.tsx
@@ -1,22 +1,45 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useId } from "react";
 import {
-  Card, CardBody, Button, Chip, Progress, Dropdown, DropdownTrigger,
-  DropdownMenu, DropdownItem, Modal, ModalContent, ModalHeader, 
-  ModalBody, ModalFooter, useDisclosure
-} from '@heroui/react';
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/contexts/AuthContext';
-import { useI18n } from '@/contexts/I18nContext';
-import { formatCurrency, formatNumber } from '@/lib/utils';
-import { dashboardAPI } from '@/lib/api';
+  Card,
+  CardBody,
+  Button,
+  Chip,
+  Progress,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+} from "@heroui/react";
+import { useRouter } from "next/navigation";
 import {
-  Users, Calendar, Check, DollarSign, Bell, Clock,
-  Bed, TrendingUp, Activity, Settings, AlertTriangle,
-  Plus, UserPlus, CalendarPlus, FileText, Stethoscope,
-  MessageCircle, Phone, Mail, ChevronDown
-} from 'lucide-react';
+  Users,
+  Calendar,
+  Check,
+  DollarSign,
+  Clock,
+  Bed,
+  TrendingUp,
+  Activity,
+  AlertTriangle,
+  UserPlus,
+  CalendarPlus,
+  FileText,
+  Stethoscope,
+  ChevronDown,
+} from "lucide-react";
+
+import { useAuth } from "@/contexts/AuthContext";
+import { useI18n } from "@/contexts/I18nContext";
+import { formatCurrency, formatNumber } from "@/lib/utils";
+import { dashboardAPI } from "@/lib/api";
 
 interface DashboardStats {
   totalPatients: number;
@@ -31,11 +54,11 @@ interface DashboardStats {
 
 interface RecentActivity {
   id: string;
-  type: 'appointment' | 'admission' | 'discharge' | 'emergency';
+  type: "appointment" | "admission" | "discharge" | "emergency";
   patient: string;
   description: string;
   time: string;
-  status: 'completed' | 'pending' | 'urgent';
+  status: "completed" | "pending" | "urgent";
 }
 
 const initialStats: DashboardStats = {
@@ -46,7 +69,7 @@ const initialStats: DashboardStats = {
   appointmentsToday: 0,
   availableRooms: 0,
   pendingTests: 0,
-  criticalAlerts: 0
+  criticalAlerts: 0,
 };
 
 export default function DashboardPage() {
@@ -56,9 +79,15 @@ export default function DashboardPage() {
   const [stats, setStats] = useState<DashboardStats>(initialStats);
   const [recentActivity, setRecentActivity] = useState<RecentActivity[]>([]);
   const [loading, setLoading] = useState(true);
-  const { isOpen: isEmergencyOpen, onOpen: onEmergencyOpen, onClose: onEmergencyClose } = useDisclosure();
-  const [emergencyType, setEmergencyType] = useState('');
-  const [emergencyDescription, setEmergencyDescription] = useState('');
+  const {
+    isOpen: isEmergencyOpen,
+    onOpen: onEmergencyOpen,
+    onClose: onEmergencyClose,
+  } = useDisclosure();
+  const [emergencyType, setEmergencyType] = useState("");
+  const [emergencyDescription, setEmergencyDescription] = useState("");
+  const emergencyTypeId = useId();
+  const emergencyDescriptionId = useId();
 
   // Fetch dashboard data on component mount
   useEffect(() => {
@@ -67,13 +96,13 @@ export default function DashboardPage() {
         setLoading(true);
         const [statsResponse, activityResponse] = await Promise.all([
           dashboardAPI.getStats(),
-          dashboardAPI.getRecentActivity()
+          dashboardAPI.getRecentActivity(),
         ]);
-        
+
         setStats(statsResponse.data);
         setRecentActivity(activityResponse.data);
       } catch (error) {
-        console.error('Error fetching dashboard data:', error);
+        console.error("Error fetching dashboard data:", error);
         // Keep initial empty state on error
       } finally {
         setLoading(false);
@@ -89,23 +118,23 @@ export default function DashboardPage() {
   // Quick Actions handlers
   const handleQuickAction = (action: string) => {
     switch (action) {
-      case 'new-patient':
-        router.push('/dashboard/patients?action=new');
+      case "new-patient":
+        router.push("/dashboard/patients?action=new");
         break;
-      case 'new-appointment':
-        router.push('/dashboard/appointments?action=new');
+      case "new-appointment":
+        router.push("/dashboard/appointments?action=new");
         break;
-      case 'new-record':
-        router.push('/dashboard/medical-records?action=new');
+      case "new-record":
+        router.push("/dashboard/medical-records?action=new");
         break;
-      case 'check-rooms':
-        router.push('/dashboard/rooms');
+      case "check-rooms":
+        router.push("/dashboard/rooms");
         break;
-      case 'staff-schedule':
-        router.push('/dashboard/staff');
+      case "staff-schedule":
+        router.push("/dashboard/staff");
         break;
-      case 'reports':
-        alert('Reports functionality coming soon!');
+      case "reports":
+        alert("Reports functionality coming soon!");
         break;
       default:
         break;
@@ -120,47 +149,56 @@ export default function DashboardPage() {
     try {
       await dashboardAPI.sendEmergencyAlert({
         type: emergencyType,
-        description: emergencyDescription
+        description: emergencyDescription,
       });
-      
-      alert('Emergency alert sent successfully to all staff!');
-      setEmergencyType('');
-      setEmergencyDescription('');
+
+      alert("Emergency alert sent successfully to all staff!");
+      setEmergencyType("");
+      setEmergencyDescription("");
       onEmergencyClose();
     } catch (error) {
-      console.error('Error sending emergency alert:', error);
-      alert('Failed to send emergency alert. Please try again.');
+      console.error("Error sending emergency alert:", error);
+      alert("Failed to send emergency alert. Please try again.");
     }
   };
 
   const handleViewAllAlerts = () => {
-    router.push('/dashboard/alerts');
+    router.push("/dashboard/alerts");
   };
 
   const handleReviewTests = () => {
-    router.push('/dashboard/tests');
+    router.push("/dashboard/tests");
   };
 
   const handleViewAllActivity = () => {
-    router.push('/dashboard/activity');
+    router.push("/dashboard/activity");
   };
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'completed': return 'success';
-      case 'pending': return 'warning';
-      case 'urgent': return 'danger';
-      default: return 'default';
+      case "completed":
+        return "success";
+      case "pending":
+        return "warning";
+      case "urgent":
+        return "danger";
+      default:
+        return "default";
     }
   };
 
   const getActivityIcon = (type: string) => {
     switch (type) {
-      case 'appointment': return <Calendar className="text-blue-500" size={16} />;
-      case 'admission': return <Users className="text-green-500" size={16} />;
-      case 'discharge': return <TrendingUp className="text-purple-500" size={16} />;
-      case 'emergency': return <AlertTriangle className="text-red-500" size={16} />;
-      default: return <Activity className="text-gray-500" size={16} />;
+      case "appointment":
+        return <Calendar className="text-blue-500" size={16} />;
+      case "admission":
+        return <Users className="text-green-500" size={16} />;
+      case "discharge":
+        return <TrendingUp className="text-purple-500" size={16} />;
+      case "emergency":
+        return <AlertTriangle className="text-red-500" size={16} />;
+      default:
+        return <Activity className="text-gray-500" size={16} />;
     }
   };
 
@@ -173,13 +211,18 @@ export default function DashboardPage() {
             Welcome back, {user?.username}!
           </h1>
           <p className="text-sm sm:text-base text-muted-foreground mt-1">
-            Here's what's happening at your hospital today.
+            Here’s what’s happening at your hospital today.
           </p>
         </div>
         <div className="flex flex-col sm:flex-row gap-2 sm:gap-3">
           <Dropdown>
             <DropdownTrigger>
-              <Button color="primary" variant="flat" size="sm" className="w-full sm:w-auto">
+              <Button
+                className="w-full sm:w-auto"
+                color="primary"
+                size="sm"
+                variant="flat"
+              >
                 <Clock className="mr-2" size={16} />
                 Quick Actions
                 <ChevronDown className="ml-2" size={14} />
@@ -189,48 +232,53 @@ export default function DashboardPage() {
               <DropdownItem
                 key="new-patient"
                 startContent={<UserPlus size={16} />}
-                onPress={() => handleQuickAction('new-patient')}
+                onPress={() => handleQuickAction("new-patient")}
               >
                 Add New Patient
               </DropdownItem>
               <DropdownItem
                 key="new-appointment"
                 startContent={<CalendarPlus size={16} />}
-                onPress={() => handleQuickAction('new-appointment')}
+                onPress={() => handleQuickAction("new-appointment")}
               >
                 Schedule Appointment
               </DropdownItem>
               <DropdownItem
                 key="new-record"
                 startContent={<FileText size={16} />}
-                onPress={() => handleQuickAction('new-record')}
+                onPress={() => handleQuickAction("new-record")}
               >
                 New Medical Record
               </DropdownItem>
               <DropdownItem
                 key="check-rooms"
                 startContent={<Bed size={16} />}
-                onPress={() => handleQuickAction('check-rooms')}
+                onPress={() => handleQuickAction("check-rooms")}
               >
                 Check Room Availability
               </DropdownItem>
               <DropdownItem
                 key="staff-schedule"
                 startContent={<Stethoscope size={16} />}
-                onPress={() => handleQuickAction('staff-schedule')}
+                onPress={() => handleQuickAction("staff-schedule")}
               >
                 Staff Schedule
               </DropdownItem>
               <DropdownItem
                 key="reports"
                 startContent={<FileText size={16} />}
-                onPress={() => handleQuickAction('reports')}
+                onPress={() => handleQuickAction("reports")}
               >
                 Generate Reports
               </DropdownItem>
             </DropdownMenu>
           </Dropdown>
-          <Button color="danger" size="sm" className="w-full sm:w-auto" onPress={handleEmergencyAlert}>
+          <Button
+            className="w-full sm:w-auto"
+            color="danger"
+            size="sm"
+            onPress={handleEmergencyAlert}
+          >
             <AlertTriangle className="mr-2" size={16} />
             Emergency Alert
           </Button>
@@ -239,10 +287,10 @@ export default function DashboardPage() {
 
       {/* Stats Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3 sm:gap-4">
-        <Card 
-          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+        <Card
           isPressable
-          onPress={() => router.push('/dashboard/patients')}
+          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+          onPress={() => router.push("/dashboard/patients")}
         >
           <CardBody className="p-4 sm:p-6">
             <div className="flex items-center gap-3 sm:gap-4">
@@ -250,69 +298,86 @@ export default function DashboardPage() {
                 <Users className="text-blue-600 dark:text-blue-400" size={20} />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs sm:text-sm text-muted-foreground">Total Patients</p>
+                <p className="text-xs sm:text-sm text-muted-foreground">
+                  Total Patients
+                </p>
                 <p className="text-lg sm:text-2xl font-bold text-foreground truncate">
-                  {loading ? '...' : formatNumber(stats.totalPatients)}
+                  {loading ? "..." : formatNumber(stats.totalPatients)}
                 </p>
               </div>
             </div>
           </CardBody>
         </Card>
 
-        <Card 
-          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+        <Card
           isPressable
-          onPress={() => router.push('/dashboard/appointments')}
+          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+          onPress={() => router.push("/dashboard/appointments")}
         >
           <CardBody className="p-4 sm:p-6">
             <div className="flex items-center gap-3 sm:gap-4">
               <div className="w-10 h-10 sm:w-12 sm:h-12 bg-green-100 dark:bg-green-900/20 rounded-lg flex items-center justify-center flex-shrink-0">
-                <Calendar className="text-green-600 dark:text-green-400" size={20} />
+                <Calendar
+                  className="text-green-600 dark:text-green-400"
+                  size={20}
+                />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs sm:text-sm text-muted-foreground">Appointments Today</p>
+                <p className="text-xs sm:text-sm text-muted-foreground">
+                  Appointments Today
+                </p>
                 <p className="text-lg sm:text-2xl font-bold text-foreground">
-                  {loading ? '...' : stats.appointmentsToday}
+                  {loading ? "..." : stats.appointmentsToday}
                 </p>
               </div>
             </div>
           </CardBody>
         </Card>
 
-        <Card 
-          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+        <Card
           isPressable
-          onPress={() => router.push('/dashboard/staff')}
+          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+          onPress={() => router.push("/dashboard/staff")}
         >
           <CardBody className="p-4 sm:p-6">
             <div className="flex items-center gap-3 sm:gap-4">
               <div className="w-10 h-10 sm:w-12 sm:h-12 bg-purple-100 dark:bg-purple-900/20 rounded-lg flex items-center justify-center flex-shrink-0">
-                <Check className="text-purple-600 dark:text-purple-400" size={20} />
+                <Check
+                  className="text-purple-600 dark:text-purple-400"
+                  size={20}
+                />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs sm:text-sm text-muted-foreground">Active Staff</p>
+                <p className="text-xs sm:text-sm text-muted-foreground">
+                  Active Staff
+                </p>
                 <p className="text-lg sm:text-2xl font-bold text-foreground">
-                  {loading ? '...' : stats.totalStaff}
+                  {loading ? "..." : stats.totalStaff}
                 </p>
               </div>
             </div>
           </CardBody>
         </Card>
 
-        <Card 
-          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+        <Card
           isPressable
-          onPress={() => router.push('/dashboard/analytics?tab=financial')}
+          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+          onPress={() => router.push("/dashboard/analytics?tab=financial")}
         >
           <CardBody className="p-4 sm:p-6">
             <div className="flex items-center gap-3 sm:gap-4">
               <div className="w-10 h-10 sm:w-12 sm:h-12 bg-yellow-100 dark:bg-yellow-900/20 rounded-lg flex items-center justify-center flex-shrink-0">
-                <DollarSign className="text-yellow-600 dark:text-yellow-400" size={20} />
+                <DollarSign
+                  className="text-yellow-600 dark:text-yellow-400"
+                  size={20}
+                />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs sm:text-sm text-muted-foreground">Monthly Revenue</p>
+                <p className="text-xs sm:text-sm text-muted-foreground">
+                  Monthly Revenue
+                </p>
                 <p className="text-lg sm:text-2xl font-bold text-foreground truncate">
-                  {loading ? '...' : formatCurrency(stats.totalRevenue)}
+                  {loading ? "..." : formatCurrency(stats.totalRevenue)}
                 </p>
               </div>
             </div>
@@ -322,25 +387,44 @@ export default function DashboardPage() {
 
       {/* Secondary Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-4">
-        <Card 
-          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+        <Card
           isPressable
-          onPress={() => router.push('/dashboard/rooms')}
+          className="w-full cursor-pointer hover:shadow-lg transition-all duration-200 hover:scale-[1.02]"
+          onPress={() => router.push("/dashboard/rooms")}
         >
           <CardBody className="p-4 sm:p-6">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-base sm:text-lg font-semibold">Room Occupancy</h3>
-              <Chip color={roomOccupancy > 80 ? 'danger' : roomOccupancy > 60 ? 'warning' : 'success'} size="sm">
+              <h3 className="text-base sm:text-lg font-semibold">
+                Room Occupancy
+              </h3>
+              <Chip
+                color={
+                  roomOccupancy > 80
+                    ? "danger"
+                    : roomOccupancy > 60
+                      ? "warning"
+                      : "success"
+                }
+                size="sm"
+              >
                 {roomOccupancy}%
               </Chip>
             </div>
             <Progress
-              value={roomOccupancy}
-              color={roomOccupancy > 80 ? 'danger' : roomOccupancy > 60 ? 'warning' : 'success'}
               className="mb-2"
+              color={
+                roomOccupancy > 80
+                  ? "danger"
+                  : roomOccupancy > 60
+                    ? "warning"
+                    : "success"
+              }
+              value={roomOccupancy}
             />
             <p className="text-xs sm:text-sm text-muted-foreground">
-              {loading ? 'Loading...' : `${stats.availableRooms} of 45 rooms available`}
+              {loading
+                ? "Loading..."
+                : `${stats.availableRooms} of 45 rooms available`}
             </p>
           </CardBody>
         </Card>
@@ -349,13 +433,24 @@ export default function DashboardPage() {
           <CardBody className="p-4 sm:p-6">
             <div className="text-center">
               <div className="w-12 h-12 sm:w-16 sm:h-16 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center mx-auto mb-3">
-                <AlertTriangle className="text-red-600 dark:text-red-400" size={24} />
+                <AlertTriangle
+                  className="text-red-600 dark:text-red-400"
+                  size={24}
+                />
               </div>
-              <h3 className="text-base sm:text-lg font-semibold mb-1">Critical Alerts</h3>
+              <h3 className="text-base sm:text-lg font-semibold mb-1">
+                Critical Alerts
+              </h3>
               <p className="text-2xl sm:text-3xl font-bold text-red-600 dark:text-red-400 mb-2">
-                {loading ? '...' : stats.criticalAlerts}
+                {loading ? "..." : stats.criticalAlerts}
               </p>
-              <Button size="sm" color="danger" variant="flat" className="w-full sm:w-auto" onPress={handleViewAllAlerts}>
+              <Button
+                className="w-full sm:w-auto"
+                color="danger"
+                size="sm"
+                variant="flat"
+                onPress={handleViewAllAlerts}
+              >
                 View All
               </Button>
             </div>
@@ -366,13 +461,24 @@ export default function DashboardPage() {
           <CardBody className="p-4 sm:p-6">
             <div className="text-center">
               <div className="w-12 h-12 sm:w-16 sm:h-16 bg-orange-100 dark:bg-orange-900/20 rounded-full flex items-center justify-center mx-auto mb-3">
-                <Clock className="text-orange-600 dark:text-orange-400" size={24} />
+                <Clock
+                  className="text-orange-600 dark:text-orange-400"
+                  size={24}
+                />
               </div>
-              <h3 className="text-base sm:text-lg font-semibold mb-1">Pending Tests</h3>
+              <h3 className="text-base sm:text-lg font-semibold mb-1">
+                Pending Tests
+              </h3>
               <p className="text-2xl sm:text-3xl font-bold text-orange-600 dark:text-orange-400 mb-2">
-                {loading ? '...' : stats.pendingTests}
+                {loading ? "..." : stats.pendingTests}
               </p>
-              <Button size="sm" color="warning" variant="flat" className="w-full sm:w-auto" onPress={handleReviewTests}>
+              <Button
+                className="w-full sm:w-auto"
+                color="warning"
+                size="sm"
+                variant="flat"
+                onPress={handleReviewTests}
+              >
                 Review
               </Button>
             </div>
@@ -384,8 +490,15 @@ export default function DashboardPage() {
       <Card className="w-full">
         <CardBody className="p-4 sm:p-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 sm:mb-6">
-            <h3 className="text-base sm:text-lg font-semibold mb-2 sm:mb-0">Recent Activity</h3>
-            <Button size="sm" variant="flat" className="w-full sm:w-auto" onPress={handleViewAllActivity}>
+            <h3 className="text-base sm:text-lg font-semibold mb-2 sm:mb-0">
+              Recent Activity
+            </h3>
+            <Button
+              className="w-full sm:w-auto"
+              size="sm"
+              variant="flat"
+              onPress={handleViewAllActivity}
+            >
               View All
             </Button>
           </div>
@@ -393,13 +506,21 @@ export default function DashboardPage() {
             {loading ? (
               <div className="text-center py-8">
                 <div className="w-16 h-16 bg-muted/50 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <Activity className="text-muted-foreground animate-pulse" size={24} />
+                  <Activity
+                    className="text-muted-foreground animate-pulse"
+                    size={24}
+                  />
                 </div>
-                <p className="text-sm text-muted-foreground">Loading recent activity...</p>
+                <p className="text-sm text-muted-foreground">
+                  Loading recent activity...
+                </p>
               </div>
             ) : recentActivity.length > 0 ? (
               recentActivity.map((activity) => (
-                <div key={activity.id} className="flex items-start sm:items-center gap-3 sm:gap-4 p-3 bg-muted/50 rounded-lg">
+                <div
+                  key={activity.id}
+                  className="flex items-start sm:items-center gap-3 sm:gap-4 p-3 bg-muted/50 rounded-lg"
+                >
                   <div className="w-8 h-8 sm:w-10 sm:h-10 bg-background rounded-full flex items-center justify-center flex-shrink-0">
                     {getActivityIcon(activity.type)}
                   </div>
@@ -408,7 +529,7 @@ export default function DashboardPage() {
                       <p className="font-medium text-foreground truncate">
                         {activity.patient}
                       </p>
-                      <Chip size="sm" color={getStatusColor(activity.status)}>
+                      <Chip color={getStatusColor(activity.status)} size="sm">
                         {activity.status}
                       </Chip>
                     </div>
@@ -426,7 +547,9 @@ export default function DashboardPage() {
                 <div className="w-16 h-16 bg-muted/50 rounded-full flex items-center justify-center mx-auto mb-4">
                   <Activity className="text-muted-foreground" size={24} />
                 </div>
-                <h4 className="text-lg font-medium text-foreground mb-2">No Recent Activity</h4>
+                <h4 className="text-lg font-medium text-foreground mb-2">
+                  No Recent Activity
+                </h4>
                 <p className="text-sm text-muted-foreground">
                   There are currently no recent activities to display.
                 </p>
@@ -437,25 +560,38 @@ export default function DashboardPage() {
       </Card>
 
       {/* Emergency Alert Modal */}
-      <Modal isOpen={isEmergencyOpen} onClose={onEmergencyClose} size="2xl">
+      <Modal isOpen={isEmergencyOpen} size="2xl" onClose={onEmergencyClose}>
         <ModalContent>
           <ModalHeader className="flex flex-col gap-1">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center">
-                <AlertTriangle className="text-red-600 dark:text-red-400" size={20} />
+                <AlertTriangle
+                  className="text-red-600 dark:text-red-400"
+                  size={20}
+                />
               </div>
               <div>
-                <h2 className="text-xl font-bold text-red-600 dark:text-red-400">Emergency Alert</h2>
-                <p className="text-sm text-muted-foreground">Send an emergency notification to all staff</p>
+                <h2 className="text-xl font-bold text-red-600 dark:text-red-400">
+                  Emergency Alert
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  Send an emergency notification to all staff
+                </p>
               </div>
             </div>
           </ModalHeader>
           <ModalBody>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-2">Emergency Type</label>
-                <select 
+                <label
+                  className="block text-sm font-medium mb-2"
+                  htmlFor={emergencyTypeId}
+                >
+                  Emergency Type
+                </label>
+                <select
                   className="w-full p-3 border border-gray-300 rounded-lg bg-background text-foreground"
+                  id={emergencyTypeId}
                   value={emergencyType}
                   onChange={(e) => setEmergencyType(e.target.value)}
                 >
@@ -469,9 +605,15 @@ export default function DashboardPage() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium mb-2">Description</label>
-                <textarea 
+                <label
+                  className="block text-sm font-medium mb-2"
+                  htmlFor={emergencyDescriptionId}
+                >
+                  Description
+                </label>
+                <textarea
                   className="w-full p-3 border border-gray-300 rounded-lg bg-background text-foreground min-h-[100px]"
+                  id={emergencyDescriptionId}
                   placeholder="Describe the emergency situation in detail..."
                   value={emergencyDescription}
                   onChange={(e) => setEmergencyDescription(e.target.value)}
@@ -479,11 +621,17 @@ export default function DashboardPage() {
               </div>
               <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700/50 rounded-lg p-4">
                 <div className="flex items-start gap-3">
-                  <AlertTriangle className="text-yellow-600 dark:text-yellow-400 mt-0.5" size={16} />
+                  <AlertTriangle
+                    className="text-yellow-600 dark:text-yellow-400 mt-0.5"
+                    size={16}
+                  />
                   <div>
-                    <h4 className="font-medium text-yellow-800 dark:text-yellow-200">Warning</h4>
+                    <h4 className="font-medium text-yellow-800 dark:text-yellow-200">
+                      Warning
+                    </h4>
                     <p className="text-sm text-yellow-700 dark:text-yellow-300 mt-1">
-                      This will send an immediate notification to all hospital staff. Only use for genuine emergencies.
+                      This will send an immediate notification to all hospital
+                      staff. Only use for genuine emergencies.
                     </p>
                   </div>
                 </div>
@@ -494,10 +642,10 @@ export default function DashboardPage() {
             <Button variant="flat" onPress={onEmergencyClose}>
               Cancel
             </Button>
-            <Button 
-              color="danger" 
-              onPress={handleEmergencySubmit}
+            <Button
+              color="danger"
               isDisabled={!emergencyType || !emergencyDescription.trim()}
+              onPress={handleEmergencySubmit}
             >
               <AlertTriangle className="mr-2" size={16} />
               Send Emergency Alert

--- a/client/app/dashboard/settings/page.tsx
+++ b/client/app/dashboard/settings/page.tsx
@@ -1,34 +1,95 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useId } from "react";
 import {
-  Card, CardBody, CardHeader, Button, Select, SelectItem, Switch,
-  Input, Divider, Tabs, Tab, Avatar, Chip, Progress, Badge,
-  Modal, ModalContent, ModalHeader, ModalBody, ModalFooter,
-  useDisclosure, Slider, RadioGroup, Radio, Accordion, AccordionItem,
-  Dropdown, DropdownTrigger, DropdownMenu, DropdownItem,
-  Tooltip, Code, Spacer, Textarea
-} from '@heroui/react';
-import { 
-  Settings as SettingsIcon, Globe, Palette, Bell, Shield, 
-  Info, User, Key, Clock, HelpCircle, Mail, Smartphone,
-  Volume2, Eye, EyeOff, Monitor, Sun, Moon, Download, Upload,
-  Database, Wifi, WifiOff, Battery, Zap, Activity, BarChart3,
-  FileText, Trash2, RefreshCw, CheckCircle, AlertTriangle,
-  Camera, Edit, Save, X, Plus, Minus, Lock, Unlock,
-  MessageSquare, Star, Settings2, Wrench, Bug, Github,
-  Heart, Coffee, Award, Target, TrendingUp, Users
-} from 'lucide-react';
-import { useI18n } from '@/contexts/I18nContext';
-import { useAuth } from '@/contexts/AuthContext';
-import { useTheme } from 'next-themes';
-import toast from 'react-hot-toast';
+  Card,
+  CardBody,
+  CardHeader,
+  Button,
+  Select,
+  SelectItem,
+  Switch,
+  Input,
+  Divider,
+  Tabs,
+  Tab,
+  Avatar,
+  Chip,
+  Progress,
+  Badge,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+  Slider,
+  RadioGroup,
+  Radio,
+  Accordion,
+  AccordionItem,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+  Tooltip,
+  Code,
+} from "@heroui/react";
+import {
+  Settings as SettingsIcon,
+  Globe,
+  Palette,
+  Bell,
+  Shield,
+  Info,
+  User,
+  Key,
+  Clock,
+  HelpCircle,
+  Mail,
+  Smartphone,
+  Volume2,
+  Eye,
+  EyeOff,
+  Monitor,
+  Sun,
+  Moon,
+  Download,
+  Upload,
+  Database,
+  Zap,
+  Activity,
+  FileText,
+  Trash2,
+  RefreshCw,
+  CheckCircle,
+  AlertTriangle,
+  Camera,
+  Edit,
+  Save,
+  Lock,
+  MessageSquare,
+  Star,
+  Settings2,
+  Bug,
+  Github,
+  Heart,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+import { useTheme } from "next-themes";
+import toast from "react-hot-toast";
+
+import { useI18n } from "@/contexts/I18nContext";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function SettingsPage() {
   const { language, setLanguage, t, languages } = useI18n();
   const { user } = useAuth();
   const { theme, setTheme } = useTheme();
-  
+  const volumeLabelId = useId();
+  const cacheSizeLabelId = useId();
+
   // Enhanced Settings state
   const [settings, setSettings] = useState({
     // Notifications
@@ -36,12 +97,12 @@ export default function SettingsPage() {
     pushNotifications: true,
     smsNotifications: false,
     soundNotifications: true,
-    notificationSound: 'default',
+    notificationSound: "default",
     notificationVolume: 75,
     quietHours: false,
-    quietStart: '22:00',
-    quietEnd: '08:00',
-    
+    quietStart: "22:00",
+    quietEnd: "08:00",
+
     // Security
     twoFactorAuth: false,
     autoLogout: true,
@@ -49,25 +110,25 @@ export default function SettingsPage() {
     loginAlerts: true,
     deviceTracking: true,
     passwordExpiry: false,
-    
+
     // Appearance
     compactMode: false,
     showAnimations: true,
     highContrast: false,
-    fontSize: 'medium',
+    fontSize: "medium",
     sidebarCollapsed: false,
-    
+
     // Privacy
     analytics: true,
     crashReporting: true,
     usageData: false,
     locationTracking: false,
-    
+
     // Performance
     autoSave: true,
     cacheSize: 100,
     offlineMode: false,
-    
+
     // Accessibility
     screenReader: false,
     keyboardNavigation: true,
@@ -76,13 +137,13 @@ export default function SettingsPage() {
 
   // System info state
   const [systemInfo, setSystemInfo] = useState({
-    platform: 'Web',
-    browser: 'Chrome',
-    version: '120.0.0',
+    platform: "Web",
+    browser: "Chrome",
+    version: "120.0.0",
     lastLogin: new Date().toISOString(),
     storageUsed: 45,
     cacheSize: 23,
-    sessionDuration: '2h 34m',
+    sessionDuration: "2h 34m",
   });
 
   // Activity stats
@@ -91,21 +152,37 @@ export default function SettingsPage() {
     patientsViewed: 89,
     reportsGenerated: 23,
     settingsChanged: 15,
-    averageSessionTime: '1h 45m',
+    averageSessionTime: "1h 45m",
     lastActive: new Date().toISOString(),
   });
 
   // Modal states
-  const { isOpen: isExportOpen, onOpen: onExportOpen, onClose: onExportClose } = useDisclosure();
-  const { isOpen: isImportOpen, onOpen: onImportOpen, onClose: onImportClose } = useDisclosure();
-  const { isOpen: isResetOpen, onOpen: onResetOpen, onClose: onResetClose } = useDisclosure();
-  const { isOpen: isAboutOpen, onOpen: onAboutOpen, onClose: onAboutClose } = useDisclosure();
+  const {
+    isOpen: isExportOpen,
+    onOpen: onExportOpen,
+    onClose: onExportClose,
+  } = useDisclosure();
+  const {
+    isOpen: isImportOpen,
+    onOpen: onImportOpen,
+    onClose: onImportClose,
+  } = useDisclosure();
+  const {
+    isOpen: isResetOpen,
+    onOpen: onResetOpen,
+    onClose: onResetClose,
+  } = useDisclosure();
+  const {
+    isOpen: isAboutOpen,
+    onOpen: onAboutOpen,
+    onClose: onAboutClose,
+  } = useDisclosure();
 
   // Password change state
   const [passwordData, setPasswordData] = useState({
-    currentPassword: '',
-    newPassword: '',
-    confirmPassword: '',
+    currentPassword: "",
+    newPassword: "",
+    confirmPassword: "",
   });
   const [showPasswords, setShowPasswords] = useState({
     current: false,
@@ -120,31 +197,40 @@ export default function SettingsPage() {
 
   useEffect(() => {
     // Load settings from localStorage on mount
-    const savedSettings = localStorage.getItem('userSettings');
+    const savedSettings = localStorage.getItem("userSettings");
+
     if (savedSettings) {
       try {
         const parsed = JSON.parse(savedSettings);
-        setSettings(prev => ({ ...prev, ...parsed }));
+
+        setSettings((prev) => ({ ...prev, ...parsed }));
       } catch (error) {
-        console.error('Failed to parse saved settings:', error);
+        console.error("Failed to parse saved settings:", error);
       }
     }
 
     // Simulate system info detection
-    setSystemInfo(prev => ({
+    setSystemInfo((prev) => ({
       ...prev,
-      browser: navigator.userAgent.includes('Chrome') ? 'Chrome' : 
-               navigator.userAgent.includes('Firefox') ? 'Firefox' : 
-               navigator.userAgent.includes('Safari') ? 'Safari' : 'Unknown',
-      platform: navigator.platform || 'Unknown',
+      browser: navigator.userAgent.includes("Chrome")
+        ? "Chrome"
+        : navigator.userAgent.includes("Firefox")
+          ? "Firefox"
+          : navigator.userAgent.includes("Safari")
+            ? "Safari"
+            : "Unknown",
+      platform: navigator.platform || "Unknown",
     }));
   }, []);
 
-  const handleSettingChange = (key: string, value: boolean | number | string) => {
-    setSettings(prev => ({ ...prev, [key]: value }));
-    
+  const handleSettingChange = (
+    key: string,
+    value: boolean | number | string,
+  ) => {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+
     // Auto-save for certain settings
-    if (['theme', 'language', 'compactMode'].includes(key)) {
+    if (["theme", "language", "compactMode"].includes(key)) {
       setTimeout(() => {
         handleSaveSettings(false);
       }, 500);
@@ -155,15 +241,15 @@ export default function SettingsPage() {
     setSaving(true);
     try {
       // Save to localStorage (in real app, would save to API)
-    localStorage.setItem('userSettings', JSON.stringify(settings));
-      
+      localStorage.setItem("userSettings", JSON.stringify(settings));
+
       if (showToast) {
-        toast.success('Ayarlar başarıyla kaydedildi!');
+        toast.success("Settings saved successfully!");
       }
     } catch (error) {
-      console.error('Failed to save settings:', error);
+      console.error("Failed to save settings:", error);
       if (showToast) {
-        toast.error('Ayarlar kaydedilirken hata oluştu');
+        toast.error("An error occurred while saving settings.");
       }
     } finally {
       setSaving(false);
@@ -172,26 +258,28 @@ export default function SettingsPage() {
 
   const handlePasswordChange = async () => {
     if (passwordData.newPassword !== passwordData.confirmPassword) {
-      toast.error('Şifreler eşleşmiyor');
+      toast.error("Passwords do not match.");
+
       return;
     }
-    
+
     if (passwordData.newPassword.length < 8) {
-      toast.error('Şifre en az 8 karakter olmalıdır');
+      toast.error("Password must be at least 8 characters long.");
+
       return;
     }
 
     try {
-    // Here you would call API to change password
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
-      toast.success('Şifre başarıyla değiştirildi!');
-    setPasswordData({
-      currentPassword: '',
-      newPassword: '',
-      confirmPassword: '',
-    });
+      // Here you would call API to change password
+      await new Promise((resolve) => setTimeout(resolve, 1000)); // Simulate API call
+      toast.success("Password updated successfully!");
+      setPasswordData({
+        currentPassword: "",
+        newPassword: "",
+        confirmPassword: "",
+      });
     } catch (error) {
-      toast.error('Şifre değiştirilirken hata oluştu');
+      toast.error("An error occurred while updating the password.");
     }
   };
 
@@ -201,49 +289,53 @@ export default function SettingsPage() {
       const exportData = {
         settings,
         exportedAt: new Date().toISOString(),
-        version: '1.0.0',
+        version: "1.0.0",
         user: user?.username,
       };
 
-      const blob = new Blob([JSON.stringify(exportData, null, 2)], { 
-        type: 'application/json' 
+      const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+        type: "application/json",
       });
       const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
+      const a = document.createElement("a");
+
       a.href = url;
-      a.download = `settings-${user?.username}-${new Date().toISOString().split('T')[0]}.json`;
+      a.download = `settings-${user?.username}-${new Date().toISOString().split("T")[0]}.json`;
       a.click();
       window.URL.revokeObjectURL(url);
-      
-      toast.success('Ayarlar başarıyla dışa aktarıldı!');
+
+      toast.success("Settings exported successfully!");
       onExportClose();
     } catch (error) {
-      toast.error('Dışa aktarma sırasında hata oluştu');
+      toast.error("An error occurred during export.");
     } finally {
       setExporting(false);
     }
   };
 
-  const handleImportSettings = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImportSettings = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
     const file = event.target.files?.[0];
+
     if (!file) return;
 
     setImporting(true);
     try {
       const text = await file.text();
       const importData = JSON.parse(text);
-      
+
       if (importData.settings) {
-        setSettings(prev => ({ ...prev, ...importData.settings }));
+        setSettings((prev) => ({ ...prev, ...importData.settings }));
         await handleSaveSettings(false);
-        toast.success('Ayarlar başarıyla içe aktarıldı!');
+        toast.success("Settings imported successfully!");
       } else {
-        throw new Error('Geçersiz ayar dosyası');
+        throw new Error("Invalid settings file");
       }
-      
+
       onImportClose();
     } catch (error) {
-      toast.error('İçe aktarma sırasında hata oluştu');
+      toast.error("An error occurred during import.");
     } finally {
       setImporting(false);
     }
@@ -257,12 +349,12 @@ export default function SettingsPage() {
         pushNotifications: true,
         smsNotifications: false,
         soundNotifications: true,
-        notificationSound: 'default',
+        notificationSound: "default",
         notificationVolume: 75,
         quietHours: false,
-        quietStart: '22:00',
-        quietEnd: '08:00',
-        
+        quietStart: "22:00",
+        quietEnd: "08:00",
+
         // Security
         twoFactorAuth: false,
         autoLogout: true,
@@ -270,25 +362,25 @@ export default function SettingsPage() {
         loginAlerts: true,
         deviceTracking: true,
         passwordExpiry: false,
-        
+
         // Appearance
         compactMode: false,
         showAnimations: true,
         highContrast: false,
-        fontSize: 'medium',
+        fontSize: "medium",
         sidebarCollapsed: false,
-        
+
         // Privacy
         analytics: true,
         crashReporting: true,
         usageData: false,
         locationTracking: false,
-        
+
         // Performance
         autoSave: true,
         cacheSize: 100,
         offlineMode: false,
-        
+
         // Accessibility
         screenReader: false,
         keyboardNavigation: true,
@@ -296,122 +388,149 @@ export default function SettingsPage() {
       };
 
       setSettings(defaultSettings);
-      localStorage.removeItem('userSettings');
-      toast.success('Ayarlar varsayılan değerlere sıfırlandı!');
+      localStorage.removeItem("userSettings");
+      toast.success("Settings were reset to default values!");
       onResetClose();
     } catch (error) {
-      toast.error('Sıfırlama sırasında hata oluştu');
+      toast.error("An error occurred while resetting settings.");
     }
   };
 
   const handleClearCache = async () => {
     try {
       // Clear various caches
-      if ('caches' in window) {
+      if ("caches" in window) {
         const cacheNames = await caches.keys();
-        await Promise.all(cacheNames.map(name => caches.delete(name)));
+
+        await Promise.all(cacheNames.map((name) => caches.delete(name)));
       }
-      
+
       // Clear localStorage except for essential data
-      const essentialKeys = ['userSettings', 'authToken'];
+      const essentialKeys = ["userSettings", "authToken"];
       const allKeys = Object.keys(localStorage);
-      allKeys.forEach(key => {
+
+      allKeys.forEach((key) => {
         if (!essentialKeys.includes(key)) {
           localStorage.removeItem(key);
         }
       });
 
-      toast.success('Önbellek başarıyla temizlendi!');
-      
+      toast.success("Cache cleared successfully!");
+
       // Update system info
-      setSystemInfo(prev => ({ ...prev, cacheSize: 0 }));
+      setSystemInfo((prev) => ({ ...prev, cacheSize: 0 }));
     } catch (error) {
-      toast.error('Önbellek temizlenirken hata oluştu');
+      toast.error("An error occurred while clearing the cache.");
     }
   };
 
   const getUserRole = () => {
-    if (!user) return t('user.guest');
+    if (!user) return t("user.guest");
     switch (user.permLevel) {
-      case 3: return 'Sistem Yöneticisi';
-      case 2: return 'Doktor';
-      case 1: return 'Hemşire';
-      default: return 'Kullanıcı';
+      case 3:
+        return "System Administrator";
+      case 2:
+        return "Doctor";
+      case 1:
+        return "Nurse";
+      default:
+        return "User";
     }
   };
 
   const getPasswordStrength = (password: string) => {
     let strength = 0;
+
     if (password.length >= 8) strength += 20;
     if (password.length >= 12) strength += 20;
     if (/[A-Z]/.test(password)) strength += 20;
     if (/[a-z]/.test(password)) strength += 20;
     if (/[0-9]/.test(password)) strength += 10;
     if (/[^A-Za-z0-9]/.test(password)) strength += 10;
+
     return Math.min(100, strength);
   };
 
   const getPasswordStrengthColor = (strength: number) => {
-    if (strength < 40) return 'danger';
-    if (strength < 70) return 'warning';
-    return 'success';
+    if (strength < 40) return "danger";
+    if (strength < 70) return "warning";
+
+    return "success";
   };
 
   const getPasswordStrengthText = (strength: number) => {
-    if (strength < 40) return 'Zayıf';
-    if (strength < 70) return 'Orta';
-    return 'Güçlü';
+    if (strength < 40) return "Weak";
+    if (strength < 70) return "Moderate";
+
+    return "Strong";
   };
 
   return (
     <div className="space-y-6">
       {/* Enhanced Header */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
-      <div className="flex items-center space-x-4">
+        <div className="flex items-center space-x-4">
           <div className="p-3 bg-gradient-to-br from-primary/20 to-primary/10 rounded-xl shadow-lg">
-          <SettingsIcon className="h-8 w-8 text-primary" />
-        </div>
-        <div>
+            <SettingsIcon className="h-8 w-8 text-primary" />
+          </div>
+          <div>
             <h1 className="text-3xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-300 bg-clip-text text-transparent">
-              Sistem Ayarları
-          </h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-1">
-              Kişiselleştirme ve güvenlik seçenekleri
-          </p>
+              System Settings
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mt-1">
+              Personalization and security options
+            </p>
+          </div>
         </div>
-      </div>
 
         {/* Quick Actions */}
         <div className="flex items-center gap-2">
           <Dropdown>
             <DropdownTrigger>
-              <Button variant="flat" startContent={<Settings2 size={16} />}>
-                Hızlı İşlemler
+              <Button startContent={<Settings2 size={16} />} variant="flat">
+                Quick Actions
               </Button>
             </DropdownTrigger>
             <DropdownMenu aria-label="Quick actions">
-              <DropdownItem key="export" startContent={<Download size={16} />} onPress={onExportOpen}>
-                Ayarları Dışa Aktar
+              <DropdownItem
+                key="export"
+                startContent={<Download size={16} />}
+                onPress={onExportOpen}
+              >
+                Export Settings
               </DropdownItem>
-              <DropdownItem key="import" startContent={<Upload size={16} />} onPress={onImportOpen}>
-                Ayarları İçe Aktar
+              <DropdownItem
+                key="import"
+                startContent={<Upload size={16} />}
+                onPress={onImportOpen}
+              >
+                Import Settings
               </DropdownItem>
-              <DropdownItem key="cache" startContent={<Trash2 size={16} />} onPress={handleClearCache}>
-                Önbelleği Temizle
+              <DropdownItem
+                key="cache"
+                startContent={<Trash2 size={16} />}
+                onPress={handleClearCache}
+              >
+                Clear Cache
               </DropdownItem>
-              <DropdownItem key="reset" startContent={<RefreshCw size={16} />} onPress={onResetOpen} color="danger">
-                Fabrika Ayarları
+              <DropdownItem
+                key="reset"
+                color="danger"
+                startContent={<RefreshCw size={16} />}
+                onPress={onResetOpen}
+              >
+                Factory Reset
               </DropdownItem>
             </DropdownMenu>
           </Dropdown>
-          
-          <Button 
-            color="primary" 
-            onPress={() => handleSaveSettings(true)}
+
+          <Button
+            color="primary"
             isLoading={saving}
             startContent={<Save size={16} />}
+            onPress={() => handleSaveSettings(true)}
           >
-            Kaydet
+            Save
           </Button>
         </div>
       </div>
@@ -422,50 +541,64 @@ export default function SettingsPage() {
           <CardBody className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Sistem Durumu</p>
-                <p className="text-xl font-semibold text-success">Çevrimiçi</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  System Status
+                </p>
+                <p className="text-xl font-semibold text-success">Online</p>
               </div>
               <CheckCircle className="text-success" size={24} />
             </div>
           </CardBody>
         </Card>
-        
+
         <Card className="border-l-4 border-l-primary">
           <CardBody className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Oturum Süresi</p>
-                <p className="text-xl font-semibold">{systemInfo.sessionDuration}</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Session Duration
+                </p>
+                <p className="text-xl font-semibold">
+                  {systemInfo.sessionDuration}
+                </p>
               </div>
               <Clock className="text-primary" size={24} />
             </div>
           </CardBody>
         </Card>
-        
+
         <Card className="border-l-4 border-l-warning">
           <CardBody className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Depolama</p>
-                <p className="text-xl font-semibold">{systemInfo.storageUsed}%</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Depolama
+                </p>
+                <p className="text-xl font-semibold">
+                  {systemInfo.storageUsed}%
+                </p>
               </div>
               <Database className="text-warning" size={24} />
             </div>
-            <Progress 
-              value={systemInfo.storageUsed} 
-              color="warning" 
-              size="sm" 
+            <Progress
               className="mt-2"
+              color="warning"
+              size="sm"
+              value={systemInfo.storageUsed}
             />
           </CardBody>
         </Card>
-        
+
         <Card className="border-l-4 border-l-secondary">
           <CardBody className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Önbellek</p>
-                <p className="text-xl font-semibold">{systemInfo.cacheSize} MB</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Cache
+                </p>
+                <p className="text-xl font-semibold">
+                  {systemInfo.cacheSize} MB
+                </p>
               </div>
               <Zap className="text-secondary" size={24} />
             </div>
@@ -476,75 +609,91 @@ export default function SettingsPage() {
       {/* Enhanced Tabs */}
       <Tabs aria-label="Settings tabs" className="w-full" variant="underlined">
         {/* Profile & General */}
-        <Tab key="profile" title={
-          <div className="flex items-center space-x-2">
-            <User className="h-4 w-4" />
-            <span>Profil</span>
-          </div>
-        }>
+        <Tab
+          key="profile"
+          title={
+            <div className="flex items-center space-x-2">
+              <User className="h-4 w-4" />
+              <span>Profil</span>
+            </div>
+          }
+        >
           <div className="space-y-6 mt-6">
             {/* Enhanced User Profile */}
             <Card className="overflow-hidden">
               <div className="bg-gradient-to-r from-primary/10 via-secondary/10 to-primary/10 p-6">
                 <div className="flex items-start justify-between">
-                <div className="flex items-center space-x-4">
+                  <div className="flex items-center space-x-4">
                     <div className="relative">
-                  <Avatar
-                    name={user?.username}
-                    size="lg"
+                      <Avatar
                         className="ring-4 ring-white/20 shadow-lg"
+                        name={user?.username}
+                        size="lg"
                       />
                       <Button
                         isIconOnly
-                        size="sm"
-                        color="primary"
                         className="absolute -bottom-1 -right-1"
+                        color="primary"
+                        size="sm"
                       >
                         <Camera size={12} />
                       </Button>
                     </div>
-                  <div>
+                    <div>
                       <h4 className="text-xl font-bold text-gray-900 dark:text-gray-100">
-                      {user?.username}
-                    </h4>
+                        {user?.username}
+                      </h4>
                       <div className="flex items-center gap-2 mt-1">
-                        <Chip size="sm" color="primary" variant="solid">
-                      {getUserRole()}
-                    </Chip>
+                        <Chip color="primary" size="sm" variant="solid">
+                          {getUserRole()}
+                        </Chip>
                       </div>
                       <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                        Son giriş: {new Date(systemInfo.lastLogin).toLocaleDateString('tr-TR')}
+                        Last login:{" "}
+                        {new Date(systemInfo.lastLogin).toLocaleDateString(
+                          "en-US",
+                        )}
                       </p>
                     </div>
                   </div>
-                  <Button variant="flat" size="sm" startContent={<Edit size={14} />}>
-                    Düzenle
+                  <Button
+                    size="sm"
+                    startContent={<Edit size={14} />}
+                    variant="flat"
+                  >
+                    Edit
                   </Button>
                 </div>
               </div>
-              
+
               <CardBody className="p-6">
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                   <div className="text-center">
                     <div className="flex items-center justify-center w-12 h-12 mx-auto mb-2 bg-primary/10 rounded-full">
                       <Activity className="text-primary" size={20} />
                     </div>
-                    <p className="text-2xl font-bold">{activityStats.totalLogins}</p>
-                    <p className="text-sm text-gray-500">Toplam Giriş</p>
+                    <p className="text-2xl font-bold">
+                      {activityStats.totalLogins}
+                    </p>
+                    <p className="text-sm text-gray-500">Total Logins</p>
                   </div>
                   <div className="text-center">
                     <div className="flex items-center justify-center w-12 h-12 mx-auto mb-2 bg-success/10 rounded-full">
                       <Users className="text-success" size={20} />
                     </div>
-                    <p className="text-2xl font-bold">{activityStats.patientsViewed}</p>
-                    <p className="text-sm text-gray-500">Hasta Görüntülendi</p>
+                    <p className="text-2xl font-bold">
+                      {activityStats.patientsViewed}
+                    </p>
+                    <p className="text-sm text-gray-500">Patients Viewed</p>
                   </div>
                   <div className="text-center">
                     <div className="flex items-center justify-center w-12 h-12 mx-auto mb-2 bg-warning/10 rounded-full">
                       <TrendingUp className="text-warning" size={20} />
                     </div>
-                    <p className="text-2xl font-bold">{activityStats.reportsGenerated}</p>
-                    <p className="text-sm text-gray-500">Rapor Oluşturuldu</p>
+                    <p className="text-2xl font-bold">
+                      {activityStats.reportsGenerated}
+                    </p>
+                    <p className="text-sm text-gray-500">Reports Generated</p>
                   </div>
                 </div>
               </CardBody>
@@ -555,36 +704,41 @@ export default function SettingsPage() {
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Globe className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Dil ve Bölge</h3>
+                  <h3 className="text-lg font-semibold">Language & Region</h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-4">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Select
-                    label="Arayüz Dili"
-                  selectedKeys={[language]}
-                  onSelectionChange={(keys) => {
-                    const selectedLang = Array.from(keys)[0] as string;
-                    setLanguage(selectedLang as 'en' | 'tr');
-                  }}
-                >
-                  {languages.map((lang) => (
-                    <SelectItem key={lang.code} textValue={lang.name}>
-                      <div className="flex items-center space-x-2">
-                        <span>{lang.flag}</span>
-                        <span>{lang.name}</span>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </Select>
-                  
                   <Select
-                    label="Saat Dilimi"
-                    defaultSelectedKeys={["Europe/Istanbul"]}
+                    label="Interface Language"
+                    selectedKeys={[language]}
+                    onSelectionChange={(keys) => {
+                      const selectedLang = Array.from(keys)[0] as string;
+
+                      setLanguage(selectedLang as "en" | "tr");
+                    }}
                   >
-                    <SelectItem key="Europe/Istanbul">İstanbul (GMT+3)</SelectItem>
-                    <SelectItem key="Europe/London">Londra (GMT+0)</SelectItem>
-                    <SelectItem key="America/New_York">New York (GMT-5)</SelectItem>
+                    {languages.map((lang) => (
+                      <SelectItem key={lang.code} textValue={lang.name}>
+                        <div className="flex items-center space-x-2">
+                          <span>{lang.flag}</span>
+                          <span>{lang.name}</span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </Select>
+
+                  <Select
+                    defaultSelectedKeys={["Europe/Istanbul"]}
+                    label="Time Zone"
+                  >
+                    <SelectItem key="Europe/Istanbul">
+                      Istanbul (GMT+3)
+                    </SelectItem>
+                    <SelectItem key="Europe/London">London (GMT+0)</SelectItem>
+                    <SelectItem key="America/New_York">
+                      New York (GMT-5)
+                    </SelectItem>
                   </Select>
                 </div>
               </CardBody>
@@ -593,63 +747,66 @@ export default function SettingsPage() {
         </Tab>
 
         {/* Appearance & Customization */}
-        <Tab key="appearance" title={
-          <div className="flex items-center space-x-2">
-            <Palette className="h-4 w-4" />
-            <span>Görünüm</span>
-          </div>
-        }>
+        <Tab
+          key="appearance"
+          title={
+            <div className="flex items-center space-x-2">
+              <Palette className="h-4 w-4" />
+              <span>Appearance</span>
+            </div>
+          }
+        >
           <div className="space-y-6 mt-6">
             {/* Theme Selection */}
             <Card>
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Palette className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Tema Seçimi</h3>
+                  <h3 className="text-lg font-semibold">Theme Selection</h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-6">
                 <RadioGroup
-                  value={theme || 'system'}
-                  onValueChange={(value) => setTheme(value)}
-                  orientation="horizontal"
                   className="gap-4"
+                  orientation="horizontal"
+                  value={theme || "system"}
+                  onValueChange={(value) => setTheme(value)}
                 >
                   <Radio
-                    value="light"
-                    description="Aydınlık tema"
                     classNames={{
                       base: "flex-1 m-0 bg-content1 hover:bg-content2 cursor-pointer rounded-lg border-2 border-default-200 data-[selected=true]:border-primary",
                       wrapper: "hidden",
                       labelWrapper: "flex flex-col items-center p-4",
                     }}
+                    description="Bright, high-contrast theme"
+                    value="light"
                   >
                     <Sun className="mb-2" size={24} />
-                    <span className="font-medium">Açık</span>
+                    <span className="font-medium">Light</span>
                   </Radio>
                   <Radio
-                    value="dark"
-                    description="Karanlık tema"
                     classNames={{
                       base: "flex-1 m-0 bg-content1 hover:bg-content2 cursor-pointer rounded-lg border-2 border-default-200 data-[selected=true]:border-primary",
                       wrapper: "hidden",
                       labelWrapper: "flex flex-col items-center p-4",
                     }}
+                    description="Low-light optimized theme"
+                    value="dark"
                   >
                     <Moon className="mb-2" size={24} />
-                    <span className="font-medium">Koyu</span>
+                    <span className="font-medium">Dark</span>
                   </Radio>
                   <Radio
-                    value="system"
-                    description="Sistem ayarı"
                     classNames={{
                       base: "flex-1 m-0 bg-content1 hover:bg-content2 cursor-pointer rounded-lg border-2 border-default-200 data-[selected=true]:border-primary",
                       wrapper: "hidden",
                       labelWrapper: "flex flex-col items-center p-4",
                     }}
+                    description="Match system preference"
+                    value="system"
                   >
                     <Monitor className="mb-2" size={24} />
-                    <span className="font-medium">Sistem</span>
+                    <span className="font-medium">System</span>
                   </Radio>
                 </RadioGroup>
               </CardBody>
@@ -658,65 +815,75 @@ export default function SettingsPage() {
             {/* Display Settings */}
             <Card>
               <CardHeader>
-                <h3 className="text-lg font-semibold">Görüntü Ayarları</h3>
+                <h3 className="text-lg font-semibold">Display Settings</h3>
               </CardHeader>
               <CardBody className="space-y-6">
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="font-medium">Kompakt Mod</p>
-                      <p className="text-sm text-gray-500">Daha az boşluk, daha fazla içerik</p>
+                      <p className="font-medium">Compact Mode</p>
+                      <p className="text-sm text-gray-500">
+                        Less spacing for more content
+                      </p>
                     </div>
                     <Switch
                       isSelected={settings.compactMode}
-                      onValueChange={(value) => handleSettingChange('compactMode', value)}
+                      onValueChange={(value) =>
+                        handleSettingChange("compactMode", value)
+                      }
                     />
                   </div>
-                  
+
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="font-medium">Animasyonlar</p>
-                      <p className="text-sm text-gray-500">Geçiş efektleri ve animasyonlar</p>
+                      <p className="font-medium">Animations</p>
+                      <p className="text-sm text-gray-500">
+                        Enable transition effects and animations
+                      </p>
                     </div>
                     <Switch
                       isSelected={settings.showAnimations}
-                      onValueChange={(value) => handleSettingChange('showAnimations', value)}
+                      onValueChange={(value) =>
+                        handleSettingChange("showAnimations", value)
+                      }
                     />
                   </div>
-                  
+
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="font-medium">Yüksek Kontrast</p>
-                      <p className="text-sm text-gray-500">Erişilebilirlik için daha belirgin renkler</p>
+                      <p className="font-medium">High Contrast</p>
+                      <p className="text-sm text-gray-500">
+                        Use more pronounced colors for accessibility
+                      </p>
                     </div>
                     <Switch
                       isSelected={settings.highContrast}
-                      onValueChange={(value) => handleSettingChange('highContrast', value)}
+                      onValueChange={(value) =>
+                        handleSettingChange("highContrast", value)
+                      }
                     />
                   </div>
                 </div>
-                
+
                 <Divider />
-                
+
                 <div className="space-y-4">
-                  <div>
-                    <label className="block text-sm font-medium mb-2">
-                      Yazı Tipi Boyutu
-                    </label>
-                <Select
-                      selectedKeys={[settings.fontSize]}
-                  onSelectionChange={(keys) => {
-                        const size = Array.from(keys)[0] as string;
-                        handleSettingChange('fontSize', size);
-                  }}
-                  className="max-w-xs"
-                >
-                      <SelectItem key="small">Küçük</SelectItem>
-                      <SelectItem key="medium">Orta</SelectItem>
-                      <SelectItem key="large">Büyük</SelectItem>
-                      <SelectItem key="xl">Çok Büyük</SelectItem>
-                </Select>
-                  </div>
+                  <Select
+                    className="max-w-xs"
+                    label="Font Size"
+                    labelPlacement="outside"
+                    selectedKeys={[settings.fontSize]}
+                    onSelectionChange={(keys) => {
+                      const size = Array.from(keys)[0] as string;
+
+                      handleSettingChange("fontSize", size);
+                    }}
+                  >
+                    <SelectItem key="small">Small</SelectItem>
+                    <SelectItem key="medium">Medium</SelectItem>
+                    <SelectItem key="large">Large</SelectItem>
+                    <SelectItem key="xl">Extra Large</SelectItem>
+                  </Select>
                 </div>
               </CardBody>
             </Card>
@@ -724,26 +891,31 @@ export default function SettingsPage() {
         </Tab>
 
         {/* Notifications */}
-        <Tab key="notifications" title={
-          <div className="flex items-center space-x-2">
-            <Bell className="h-4 w-4" />
-            <span>Bildirimler</span>
-            <Badge content="3" color="danger" size="sm">
-              <span></span>
-            </Badge>
-          </div>
-        }>
+        <Tab
+          key="notifications"
+          title={
+            <div className="flex items-center space-x-2">
+              <Bell className="h-4 w-4" />
+              <span>Notifications</span>
+              <Badge color="danger" content="3" size="sm">
+                <span />
+              </Badge>
+            </div>
+          }
+        >
           <div className="space-y-6 mt-6">
             {/* Notification Types */}
             <Card>
               <CardHeader>
                 <div className="flex items-center justify-between w-full">
-                <div className="flex items-center space-x-2">
-                  <Bell className="h-5 w-5 text-primary" />
-                    <h3 className="text-lg font-semibold">Bildirim Türleri</h3>
+                  <div className="flex items-center space-x-2">
+                    <Bell className="h-5 w-5 text-primary" />
+                    <h3 className="text-lg font-semibold">
+                      Notification Types
+                    </h3>
                   </div>
-                  <Chip size="sm" variant="flat" color="primary">
-                    {Object.values(settings).filter(Boolean).length} aktif
+                  <Chip color="primary" size="sm" variant="flat">
+                    {Object.values(settings).filter(Boolean).length} active
                   </Chip>
                 </div>
               </CardHeader>
@@ -753,61 +925,65 @@ export default function SettingsPage() {
                     key="email"
                     title={
                       <div className="flex items-center justify-between w-full">
-                  <div className="flex items-center space-x-3">
-                    <Mail className="h-5 w-5 text-gray-500" />
-                          <span>E-posta Bildirimleri</span>
-                  </div>
-                  <Switch
-                    isSelected={settings.emailNotifications}
-                    onValueChange={(value) => handleSettingChange('emailNotifications', value)}
+                        <div className="flex items-center space-x-3">
+                          <Mail className="h-5 w-5 text-gray-500" />
+                          <span>Email Notifications</span>
+                        </div>
+                        <Switch
+                          isSelected={settings.emailNotifications}
                           size="sm"
-                  />
-                </div>
+                          onValueChange={(value) =>
+                            handleSettingChange("emailNotifications", value)
+                          }
+                        />
+                      </div>
                     }
                   >
                     <div className="pl-8 space-y-3">
                       <p className="text-sm text-gray-600 dark:text-gray-400">
-                        Önemli güncellemeler ve sistem bildirimleri e-posta ile gönderilir.
+                        Important updates and system notices are sent by email.
                       </p>
-                <div className="flex items-center justify-between">
-                        <span className="text-sm">Hasta randevuları</span>
-                        <Switch size="sm" defaultSelected />
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm">Patient appointments</span>
+                        <Switch defaultSelected size="sm" />
                       </div>
                       <div className="flex items-center justify-between">
-                        <span className="text-sm">Sistem güncellemeleri</span>
-                        <Switch size="sm" defaultSelected />
+                        <span className="text-sm">System updates</span>
+                        <Switch defaultSelected size="sm" />
                       </div>
                       <div className="flex items-center justify-between">
-                        <span className="text-sm">Güvenlik uyarıları</span>
-                        <Switch size="sm" defaultSelected />
+                        <span className="text-sm">Security alerts</span>
+                        <Switch defaultSelected size="sm" />
                       </div>
                     </div>
                   </AccordionItem>
-                  
+
                   <AccordionItem
                     key="push"
                     title={
                       <div className="flex items-center justify-between w-full">
-                  <div className="flex items-center space-x-3">
-                    <Smartphone className="h-5 w-5 text-gray-500" />
-                          <span>Anlık Bildirimler</span>
-                  </div>
-                  <Switch
-                    isSelected={settings.pushNotifications}
-                    onValueChange={(value) => handleSettingChange('pushNotifications', value)}
+                        <div className="flex items-center space-x-3">
+                          <Smartphone className="h-5 w-5 text-gray-500" />
+                          <span>Push Notifications</span>
+                        </div>
+                        <Switch
+                          isSelected={settings.pushNotifications}
                           size="sm"
-                  />
-                </div>
+                          onValueChange={(value) =>
+                            handleSettingChange("pushNotifications", value)
+                          }
+                        />
+                      </div>
                     }
                   >
                     <div className="pl-8 space-y-3">
-                <div className="flex items-center justify-between">
-                        <span className="text-sm">Acil durumlar</span>
-                        <Switch size="sm" defaultSelected />
-                  </div>
                       <div className="flex items-center justify-between">
-                        <span className="text-sm">Randevu hatırlatmaları</span>
-                        <Switch size="sm" defaultSelected />
+                        <span className="text-sm">Emergency alerts</span>
+                        <Switch defaultSelected size="sm" />
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm">Appointment reminders</span>
+                        <Switch defaultSelected size="sm" />
                       </div>
                     </div>
                   </AccordionItem>
@@ -820,53 +996,65 @@ export default function SettingsPage() {
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Volume2 className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Ses Ayarları</h3>
+                  <h3 className="text-lg font-semibold">Sound Settings</h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-4">
                 <div className="flex items-center justify-between">
-                  <span>Ses Bildirimleri</span>
+                  <span>Sound Notifications</span>
                   <Switch
                     isSelected={settings.soundNotifications}
-                    onValueChange={(value) => handleSettingChange('soundNotifications', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("soundNotifications", value)
+                    }
                   />
                 </div>
-                
+
                 {settings.soundNotifications && (
                   <>
                     <div className="space-y-2">
-                      <label className="text-sm font-medium">Ses Seviyesi</label>
+                      <label
+                        className="text-sm font-medium"
+                        htmlFor={`${volumeLabelId}-slider`}
+                        id={volumeLabelId}
+                      >
+                        Volume
+                      </label>
                       <Slider
+                        aria-labelledby={volumeLabelId}
+                        className="max-w-md"
+                        color="primary"
+                        id={`${volumeLabelId}-slider`}
+                        maxValue={100}
+                        step={5}
                         value={[settings.notificationVolume]}
                         onChange={(value: number | number[]) => {
                           const vol = Array.isArray(value) ? value[0] : value;
-                          handleSettingChange('notificationVolume', vol);
+
+                          handleSettingChange("notificationVolume", vol);
                         }}
-                        maxValue={100}
-                        step={5}
-                        className="max-w-md"
-                        color="primary"
                       />
                       <div className="flex justify-between text-xs text-gray-500">
-                        <span>Sessiz</span>
+                        <span>Mute</span>
                         <span>{settings.notificationVolume}%</span>
-                        <span>Yüksek</span>
+                        <span>High</span>
                       </div>
                     </div>
-                    
+
                     <Select
-                      label="Bildirim Sesi"
+                      className="max-w-xs"
+                      label="Notification Sound"
                       selectedKeys={[settings.notificationSound]}
                       onSelectionChange={(keys) => {
                         const sound = Array.from(keys)[0] as string;
-                        handleSettingChange('notificationSound', sound);
+
+                        handleSettingChange("notificationSound", sound);
                       }}
-                      className="max-w-xs"
                     >
-                      <SelectItem key="default">Varsayılan</SelectItem>
-                      <SelectItem key="chime">Çan</SelectItem>
-                      <SelectItem key="alert">Uyarı</SelectItem>
-                      <SelectItem key="notification">Bildirim</SelectItem>
+                      <SelectItem key="default">Default</SelectItem>
+                      <SelectItem key="chime">Chime</SelectItem>
+                      <SelectItem key="alert">Alert</SelectItem>
+                      <SelectItem key="notification">Notification</SelectItem>
                     </Select>
                   </>
                 )}
@@ -878,34 +1066,42 @@ export default function SettingsPage() {
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Moon className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Sessiz Saatler</h3>
+                  <h3 className="text-lg font-semibold">Quiet Hours</h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Sessiz Saatleri Etkinleştir</p>
-                    <p className="text-sm text-gray-500">Belirtilen saatlerde bildirimi sessize al</p>
+                    <p className="font-medium">Enable Quiet Hours</p>
+                    <p className="text-sm text-gray-500">
+                      Silence notifications during the selected hours
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.quietHours}
-                    onValueChange={(value) => handleSettingChange('quietHours', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("quietHours", value)
+                    }
                   />
                 </div>
-                
+
                 {settings.quietHours && (
                   <div className="grid grid-cols-2 gap-4">
                     <Input
+                      label="Start"
                       type="time"
-                      label="Başlangıç"
                       value={settings.quietStart}
-                      onChange={(e) => handleSettingChange('quietStart', e.target.value)}
+                      onChange={(e) =>
+                        handleSettingChange("quietStart", e.target.value)
+                      }
                     />
                     <Input
+                      label="End"
                       type="time"
-                      label="Bitiş"
                       value={settings.quietEnd}
-                      onChange={(e) => handleSettingChange('quietEnd', e.target.value)}
+                      onChange={(e) =>
+                        handleSettingChange("quietEnd", e.target.value)
+                      }
                     />
                   </div>
                 )}
@@ -915,97 +1111,164 @@ export default function SettingsPage() {
         </Tab>
 
         {/* Security & Privacy */}
-        <Tab key="security" title={
-          <div className="flex items-center space-x-2">
-            <Shield className="h-4 w-4" />
-            <span>Güvenlik</span>
-          </div>
-        }>
+        <Tab
+          key="security"
+          title={
+            <div className="flex items-center space-x-2">
+              <Shield className="h-4 w-4" />
+              <span>Security</span>
+            </div>
+          }
+        >
           <div className="space-y-6 mt-6">
             {/* Password Settings */}
             <Card>
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Key className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Şifre Ayarları</h3>
+                  <h3 className="text-lg font-semibold">Password Settings</h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-4">
                 <Input
-                  label="Mevcut Şifre"
-                  type={showPasswords.current ? 'text' : 'password'}
-                  value={passwordData.currentPassword}
-                  onChange={(e) => setPasswordData(prev => ({ ...prev, currentPassword: e.target.value }))}
                   endContent={
                     <button
-                      type="button"
-                      onClick={() => setShowPasswords(prev => ({ ...prev, current: !prev.current }))}
                       className="focus:outline-none"
-                    >
-                      {showPasswords.current ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                    </button>
-                  }
-                />
-                
-                <div className="space-y-2">
-                <Input
-                    label="Yeni Şifre"
-                  type={showPasswords.new ? 'text' : 'password'}
-                  value={passwordData.newPassword}
-                  onChange={(e) => setPasswordData(prev => ({ ...prev, newPassword: e.target.value }))}
-                  endContent={
-                    <button
                       type="button"
-                      onClick={() => setShowPasswords(prev => ({ ...prev, new: !prev.new }))}
-                        className="focus:outline-none"
+                      onClick={() =>
+                        setShowPasswords((prev) => ({
+                          ...prev,
+                          current: !prev.current,
+                        }))
+                      }
                     >
-                      {showPasswords.new ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      {showPasswords.current ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
                     </button>
                   }
+                  label="Current Password"
+                  type={showPasswords.current ? "text" : "password"}
+                  value={passwordData.currentPassword}
+                  onChange={(e) =>
+                    setPasswordData((prev) => ({
+                      ...prev,
+                      currentPassword: e.target.value,
+                    }))
+                  }
                 />
-                  
+
+                <div className="space-y-2">
+                  <Input
+                    endContent={
+                      <button
+                        className="focus:outline-none"
+                        type="button"
+                        onClick={() =>
+                          setShowPasswords((prev) => ({
+                            ...prev,
+                            new: !prev.new,
+                          }))
+                        }
+                      >
+                        {showPasswords.new ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </button>
+                    }
+                    label="New Password"
+                    type={showPasswords.new ? "text" : "password"}
+                    value={passwordData.newPassword}
+                    onChange={(e) =>
+                      setPasswordData((prev) => ({
+                        ...prev,
+                        newPassword: e.target.value,
+                      }))
+                    }
+                  />
+
                   {passwordData.newPassword && (
                     <div className="space-y-2">
                       <div className="flex items-center justify-between text-sm">
-                        <span>Şifre Gücü:</span>
-                        <span className={`font-medium text-${getPasswordStrengthColor(getPasswordStrength(passwordData.newPassword))}`}>
-                          {getPasswordStrengthText(getPasswordStrength(passwordData.newPassword))}
+                        <span>Password Strength:</span>
+                        <span
+                          className={`font-medium text-${getPasswordStrengthColor(getPasswordStrength(passwordData.newPassword))}`}
+                        >
+                          {getPasswordStrengthText(
+                            getPasswordStrength(passwordData.newPassword),
+                          )}
                         </span>
                       </div>
                       <Progress
-                        value={getPasswordStrength(passwordData.newPassword)}
-                        color={getPasswordStrengthColor(getPasswordStrength(passwordData.newPassword)) as any}
+                        color={
+                          getPasswordStrengthColor(
+                            getPasswordStrength(passwordData.newPassword),
+                          ) as any
+                        }
                         size="sm"
+                        value={getPasswordStrength(passwordData.newPassword)}
                       />
                     </div>
                   )}
                 </div>
-                
+
                 <Input
-                  label="Şifre Tekrarı"
-                  type={showPasswords.confirm ? 'text' : 'password'}
-                  value={passwordData.confirmPassword}
-                  onChange={(e) => setPasswordData(prev => ({ ...prev, confirmPassword: e.target.value }))}
+                  color={
+                    passwordData.confirmPassword &&
+                    passwordData.newPassword !== passwordData.confirmPassword
+                      ? "danger"
+                      : "default"
+                  }
                   endContent={
                     <button
-                      type="button"
-                      onClick={() => setShowPasswords(prev => ({ ...prev, confirm: !prev.confirm }))}
                       className="focus:outline-none"
+                      type="button"
+                      onClick={() =>
+                        setShowPasswords((prev) => ({
+                          ...prev,
+                          confirm: !prev.confirm,
+                        }))
+                      }
                     >
-                      {showPasswords.confirm ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      {showPasswords.confirm ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
                     </button>
                   }
-                  color={passwordData.confirmPassword && passwordData.newPassword !== passwordData.confirmPassword ? 'danger' : 'default'}
-                  errorMessage={passwordData.confirmPassword && passwordData.newPassword !== passwordData.confirmPassword ? 'Şifreler eşleşmiyor' : ''}
+                  errorMessage={
+                    passwordData.confirmPassword &&
+                    passwordData.newPassword !== passwordData.confirmPassword
+                      ? "Passwords do not match"
+                      : ""
+                  }
+                  label="Confirm Password"
+                  type={showPasswords.confirm ? "text" : "password"}
+                  value={passwordData.confirmPassword}
+                  onChange={(e) =>
+                    setPasswordData((prev) => ({
+                      ...prev,
+                      confirmPassword: e.target.value,
+                    }))
+                  }
                 />
-                
-                <Button 
-                  color="primary" 
-                  onPress={handlePasswordChange}
-                  isDisabled={!passwordData.currentPassword || !passwordData.newPassword || passwordData.newPassword !== passwordData.confirmPassword}
+
+                <Button
                   className="w-full"
+                  color="primary"
+                  isDisabled={
+                    !passwordData.currentPassword ||
+                    !passwordData.newPassword ||
+                    passwordData.newPassword !== passwordData.confirmPassword
+                  }
+                  onPress={handlePasswordChange}
                 >
-                  Şifreyi Değiştir
+                  Change Password
                 </Button>
               </CardBody>
             </Card>
@@ -1015,32 +1278,47 @@ export default function SettingsPage() {
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Shield className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">İki Faktörlü Doğrulama</h3>
+                  <h3 className="text-lg font-semibold">
+                    Two-Factor Authentication
+                  </h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">2FA Etkinleştir</p>
-                    <p className="text-sm text-gray-500">Hesabınızın güvenliğini artırın</p>
+                    <p className="font-medium">Enable 2FA</p>
+                    <p className="text-sm text-gray-500">
+                      Increase the security of your account
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.twoFactorAuth}
-                    onValueChange={(value) => handleSettingChange('twoFactorAuth', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("twoFactorAuth", value)
+                    }
                   />
                 </div>
-                
+
                 {settings.twoFactorAuth && (
                   <div className="p-4 bg-warning/10 rounded-lg border border-warning/20">
                     <div className="flex items-start space-x-3">
-                      <AlertTriangle className="text-warning mt-0.5" size={20} />
+                      <AlertTriangle
+                        className="text-warning mt-0.5"
+                        size={20}
+                      />
                       <div>
-                        <p className="font-medium text-warning">2FA Aktif</p>
+                        <p className="font-medium text-warning">2FA Active</p>
                         <p className="text-sm text-gray-600 dark:text-gray-400">
-                          Google Authenticator veya benzer bir uygulama kullanarak QR kodu tarayın.
+                          Scan the QR code using Google Authenticator or a
+                          similar app.
                         </p>
-                        <Button size="sm" variant="flat" color="warning" className="mt-2">
-                          QR Kodu Göster
+                        <Button
+                          className="mt-2"
+                          color="warning"
+                          size="sm"
+                          variant="flat"
+                        >
+                          Show QR Code
                         </Button>
                       </div>
                     </div>
@@ -1052,54 +1330,73 @@ export default function SettingsPage() {
             {/* Session & Access */}
             <Card>
               <CardHeader>
-                <h3 className="text-lg font-semibold">Oturum ve Erişim</h3>
+                <h3 className="text-lg font-semibold">Session & Access</h3>
               </CardHeader>
               <CardBody className="space-y-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Otomatik Çıkış</p>
-                    <p className="text-sm text-gray-500">Hareketsizlik durumunda çıkış yap</p>
+                    <p className="font-medium">Automatic Logout</p>
+                    <p className="text-sm text-gray-500">
+                      Sign out after periods of inactivity
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.autoLogout}
-                    onValueChange={(value) => handleSettingChange('autoLogout', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("autoLogout", value)
+                    }
                   />
                 </div>
-                
+
                 {settings.autoLogout && (
                   <div className="pl-4">
-                <Input
-                      label="Zaman Aşımı (dakika)"
-                  type="number"
-                  value={settings.sessionTimeout.toString()}
-                      onChange={(e) => handleSettingChange('sessionTimeout', parseInt(e.target.value) || 30)}
-                      endContent={<span className="text-sm text-gray-500">dk</span>}
-                  className="max-w-xs"
-                      min={5}
+                    <Input
+                      className="max-w-xs"
+                      endContent={
+                        <span className="text-sm text-gray-500">min</span>
+                      }
+                      label="Timeout (minutes)"
                       max={480}
+                      min={5}
+                      type="number"
+                      value={settings.sessionTimeout.toString()}
+                      onChange={(e) =>
+                        handleSettingChange(
+                          "sessionTimeout",
+                          parseInt(e.target.value) || 30,
+                        )
+                      }
                     />
                   </div>
                 )}
-                
+
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Giriş Uyarıları</p>
-                    <p className="text-sm text-gray-500">Yeni cihaz girişlerinde bildir</p>
+                    <p className="font-medium">Login Alerts</p>
+                    <p className="text-sm text-gray-500">
+                      Notify when new devices sign in
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.loginAlerts}
-                    onValueChange={(value) => handleSettingChange('loginAlerts', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("loginAlerts", value)
+                    }
                   />
                 </div>
-                
+
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Cihaz Takibi</p>
-                    <p className="text-sm text-gray-500">Aktif oturumları izle</p>
+                    <p className="font-medium">Device Tracking</p>
+                    <p className="text-sm text-gray-500">
+                      Monitor active sessions
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.deviceTracking}
-                    onValueChange={(value) => handleSettingChange('deviceTracking', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("deviceTracking", value)
+                    }
                   />
                 </div>
               </CardBody>
@@ -1108,19 +1405,22 @@ export default function SettingsPage() {
         </Tab>
 
         {/* System & Performance */}
-        <Tab key="system" title={
-          <div className="flex items-center space-x-2">
-            <Activity className="h-4 w-4" />
-            <span>Sistem</span>
-          </div>
-        }>
+        <Tab
+          key="system"
+          title={
+            <div className="flex items-center space-x-2">
+              <Activity className="h-4 w-4" />
+              <span>System</span>
+            </div>
+          }
+        >
           <div className="space-y-6 mt-6">
             {/* System Information */}
             <Card>
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Monitor className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Sistem Bilgileri</h3>
+                  <h3 className="text-lg font-semibold">System Information</h3>
                 </div>
               </CardHeader>
               <CardBody>
@@ -1130,23 +1430,23 @@ export default function SettingsPage() {
                     <p className="font-medium">{systemInfo.platform}</p>
                   </div>
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">Tarayıcı</p>
+                    <p className="text-sm text-gray-500">Browser</p>
                     <p className="font-medium">{systemInfo.browser}</p>
                   </div>
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">Versiyon</p>
+                    <p className="text-sm text-gray-500">Version</p>
                     <p className="font-medium">v2.1.0</p>
                   </div>
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">Son Güncelleme</p>
-                    <p className="font-medium">15 Şubat 2024</p>
+                    <p className="text-sm text-gray-500">Last Updated</p>
+                    <p className="font-medium">February 15, 2024</p>
                   </div>
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">Çalışma Süresi</p>
+                    <p className="text-sm text-gray-500">Uptime</p>
                     <p className="font-medium">{systemInfo.sessionDuration}</p>
                   </div>
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">Bellek Kullanımı</p>
+                    <p className="text-sm text-gray-500">Memory Usage</p>
                     <p className="font-medium">127 MB</p>
                   </div>
                 </div>
@@ -1158,45 +1458,64 @@ export default function SettingsPage() {
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Zap className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Performans Ayarları</h3>
+                  <h3 className="text-lg font-semibold">
+                    Performance Settings
+                  </h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Otomatik Kaydetme</p>
-                    <p className="text-sm text-gray-500">Değişiklikleri otomatik olarak kaydet</p>
+                    <p className="font-medium">Auto Save</p>
+                    <p className="text-sm text-gray-500">
+                      Automatically store changes
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.autoSave}
-                    onValueChange={(value) => handleSettingChange('autoSave', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("autoSave", value)
+                    }
                   />
                 </div>
-                
+
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Çevrimdışı Mod</p>
-                    <p className="text-sm text-gray-500">İnternet bağlantısı olmadan çalış</p>
+                    <p className="font-medium">Offline Mode</p>
+                    <p className="text-sm text-gray-500">
+                      Work without an internet connection
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.offlineMode}
-                    onValueChange={(value) => handleSettingChange('offlineMode', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("offlineMode", value)
+                    }
                   />
                 </div>
-                
+
                 <div className="space-y-2">
-                  <label className="text-sm font-medium">Önbellek Boyutu (MB)</label>
+                  <label
+                    className="text-sm font-medium"
+                    htmlFor={`${cacheSizeLabelId}-slider`}
+                    id={cacheSizeLabelId}
+                  >
+                    Cache Size (MB)
+                  </label>
                   <Slider
-                    value={[settings.cacheSize]}
-                    onChange={(value: number | number[]) => {
-                      const size = Array.isArray(value) ? value[0] : value;
-                      handleSettingChange('cacheSize', size);
-                    }}
+                    aria-labelledby={cacheSizeLabelId}
+                    className="max-w-md"
+                    color="primary"
+                    id={`${cacheSizeLabelId}-slider`}
                     maxValue={500}
                     minValue={50}
                     step={25}
-                    className="max-w-md"
-                    color="primary"
+                    value={[settings.cacheSize]}
+                    onChange={(value: number | number[]) => {
+                      const size = Array.isArray(value) ? value[0] : value;
+
+                      handleSettingChange("cacheSize", size);
+                    }}
                   />
                   <div className="flex justify-between text-xs text-gray-500">
                     <span>50 MB</span>
@@ -1204,21 +1523,21 @@ export default function SettingsPage() {
                     <span>500 MB</span>
                   </div>
                 </div>
-                
+
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <Button 
-                    variant="flat" 
-                    onPress={handleClearCache}
+                  <Button
                     startContent={<Trash2 size={16} />}
+                    variant="flat"
+                    onPress={handleClearCache}
                   >
-                    Önbelleği Temizle
+                    Clear Cache
                   </Button>
-                  <Button 
-                    variant="flat" 
+                  <Button
                     color="warning"
                     startContent={<RefreshCw size={16} />}
+                    variant="flat"
                   >
-                    Sayfayı Yenile
+                    Refresh Page
                   </Button>
                 </div>
               </CardBody>
@@ -1229,40 +1548,52 @@ export default function SettingsPage() {
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <Lock className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Gizlilik</h3>
+                  <h3 className="text-lg font-semibold">Privacy</h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Analitik Veriler</p>
-                    <p className="text-sm text-gray-500">Kullanım istatistiklerini paylaş</p>
+                    <p className="font-medium">Analytics</p>
+                    <p className="text-sm text-gray-500">
+                      Share usage statistics
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.analytics}
-                    onValueChange={(value) => handleSettingChange('analytics', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("analytics", value)
+                    }
                   />
                 </div>
-                
+
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Çökme Raporları</p>
-                    <p className="text-sm text-gray-500">Hata raporlarını otomatik gönder</p>
+                    <p className="font-medium">Crash Reports</p>
+                    <p className="text-sm text-gray-500">
+                      Automatically send error reports
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.crashReporting}
-                    onValueChange={(value) => handleSettingChange('crashReporting', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("crashReporting", value)
+                    }
                   />
                 </div>
-                
+
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium">Kullanım Verileri</p>
-                    <p className="text-sm text-gray-500">Özellik kullanımını takip et</p>
+                    <p className="font-medium">Usage Data</p>
+                    <p className="text-sm text-gray-500">
+                      Track feature adoption
+                    </p>
                   </div>
                   <Switch
                     isSelected={settings.usageData}
-                    onValueChange={(value) => handleSettingChange('usageData', value)}
+                    onValueChange={(value) =>
+                      handleSettingChange("usageData", value)
+                    }
                   />
                 </div>
               </CardBody>
@@ -1271,12 +1602,15 @@ export default function SettingsPage() {
         </Tab>
 
         {/* About & Support */}
-        <Tab key="about" title={
-          <div className="flex items-center space-x-2">
-            <Info className="h-4 w-4" />
-            <span>Hakkında</span>
-          </div>
-        }>
+        <Tab
+          key="about"
+          title={
+            <div className="flex items-center space-x-2">
+              <Info className="h-4 w-4" />
+              <span>About</span>
+            </div>
+          }
+        >
           <div className="space-y-6 mt-6">
             {/* App Information */}
             <Card className="overflow-hidden">
@@ -1285,37 +1619,40 @@ export default function SettingsPage() {
                   <div className="flex items-center justify-center w-16 h-16 mx-auto mb-4 bg-white/20 rounded-full">
                     <Heart className="text-primary" size={32} />
                   </div>
-                  <h2 className="text-2xl font-bold mb-2">Hospital Management System</h2>
+                  <h2 className="text-2xl font-bold mb-2">
+                    Hospital Management System
+                  </h2>
                   <p className="text-gray-600 dark:text-gray-400">
-                    Hastane Yönetim Sistemi v2.1.0
+                    Hospital Management System v2.1.0
                   </p>
                 </div>
               </div>
-              
+
               <CardBody className="p-6">
                 <div className="text-center space-y-4">
                   <p className="text-gray-600 dark:text-gray-400">
-                    Modern hastane yönetimi için tasarlanmış, kullanıcı dostu ve güvenli platform.
+                    A modern, user-friendly, and secure platform designed for
+                    hospital operations.
                   </p>
-                  
+
                   <div className="flex items-center justify-center space-x-6">
                     <Tooltip content="GitHub">
-                      <Button isIconOnly variant="flat" size="sm">
+                      <Button isIconOnly size="sm" variant="flat">
                         <Github size={16} />
-                  </Button>
+                      </Button>
                     </Tooltip>
-                    <Tooltip content="Dokümantasyon">
-                      <Button isIconOnly variant="flat" size="sm">
+                    <Tooltip content="Documentation">
+                      <Button isIconOnly size="sm" variant="flat">
                         <FileText size={16} />
-                  </Button>
+                      </Button>
                     </Tooltip>
-                    <Tooltip content="Destek">
-                      <Button isIconOnly variant="flat" size="sm">
+                    <Tooltip content="Support">
+                      <Button isIconOnly size="sm" variant="flat">
                         <MessageSquare size={16} />
                       </Button>
                     </Tooltip>
-                    <Tooltip content="Değerlendirin">
-                      <Button isIconOnly variant="flat" size="sm">
+                    <Tooltip content="Rate Us">
+                      <Button isIconOnly size="sm" variant="flat">
                         <Star size={16} />
                       </Button>
                     </Tooltip>
@@ -1327,25 +1664,25 @@ export default function SettingsPage() {
             {/* Version Information */}
             <Card>
               <CardHeader>
-                <h3 className="text-lg font-semibold">Sürüm Bilgileri</h3>
+                <h3 className="text-lg font-semibold">Version Information</h3>
               </CardHeader>
               <CardBody>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">Uygulama Sürümü</p>
+                    <p className="text-sm text-gray-500">Application Version</p>
                     <Code size="sm">v2.1.0</Code>
                   </div>
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">Build Numarası</p>
+                    <p className="text-sm text-gray-500">Build Number</p>
                     <Code size="sm">2024.02.15.001</Code>
                   </div>
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">API Sürümü</p>
+                    <p className="text-sm text-gray-500">API Version</p>
                     <Code size="sm">v1.0.0</Code>
                   </div>
                   <div className="space-y-1">
-                    <p className="text-sm text-gray-500">Son Güncelleme</p>
-                    <Code size="sm">15 Şubat 2024</Code>
+                    <p className="text-sm text-gray-500">Last Update</p>
+                    <Code size="sm">February 15, 2024</Code>
                   </div>
                 </div>
               </CardBody>
@@ -1356,48 +1693,45 @@ export default function SettingsPage() {
               <CardHeader>
                 <div className="flex items-center space-x-2">
                   <MessageSquare className="h-5 w-5 text-primary" />
-                  <h3 className="text-lg font-semibold">Destek ve Geri Bildirim</h3>
+                  <h3 className="text-lg font-semibold">Support & Feedback</h3>
                 </div>
               </CardHeader>
               <CardBody className="space-y-4">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <Button 
-                    variant="flat" 
+                  <Button
                     startContent={<HelpCircle size={16} />}
+                    variant="flat"
                     onPress={onAboutOpen}
                   >
-                    Yardım Merkezi
+                    Help Center
                   </Button>
-                  <Button 
-                    variant="flat" 
-                    startContent={<Mail size={16} />}
-                  >
-                    İletişim
+                  <Button startContent={<Mail size={16} />} variant="flat">
+                    Contact
                   </Button>
-                  <Button 
-                    variant="flat" 
-                    startContent={<Bug size={16} />}
-                  >
-                    Hata Bildir
+                  <Button startContent={<Bug size={16} />} variant="flat">
+                    Report Issue
                   </Button>
-                  <Button 
-                    variant="flat" 
-                    startContent={<Star size={16} />}
-                  >
-                    Değerlendir
+                  <Button startContent={<Star size={16} />} variant="flat">
+                    Rate Us
                   </Button>
                 </div>
-                
+
                 <Divider />
-                
+
                 <div className="text-center space-y-2">
                   <p className="text-sm text-gray-600 dark:text-gray-400">
-                    © 2025 Hospital Management System. Tüm hakları saklıdır.
+                    © 2025 Hospital Management System. All rights reserved.
                   </p>
                   <div className="flex items-center justify-center space-x-4 text-xs text-gray-500">
-                    <Button variant="light" size="sm">Gizlilik Politikası</Button>
-                    <Button variant="light" size="sm">Kullanım Şartları</Button>
-                    <Button variant="light" size="sm">Lisans</Button>
+                    <Button size="sm" variant="light">
+                      Privacy Policy
+                    </Button>
+                    <Button size="sm" variant="light">
+                      Terms of Use
+                    </Button>
+                    <Button size="sm" variant="light">
+                      Licenses
+                    </Button>
                   </div>
                 </div>
               </CardBody>
@@ -1410,23 +1744,23 @@ export default function SettingsPage() {
       {/* Export Modal */}
       <Modal isOpen={isExportOpen} onClose={onExportClose}>
         <ModalContent>
-          <ModalHeader>Ayarları Dışa Aktar</ModalHeader>
+          <ModalHeader>Export Settings</ModalHeader>
           <ModalBody>
             <p>
-              Tüm kişisel ayarlarınız bir JSON dosyası olarak kaydedilecek. 
-              Bu dosyayı başka bir cihazda içe aktarabilirsiniz.
+              All of your personal settings will be saved as a JSON file. You
+              can import this file on another device.
             </p>
           </ModalBody>
           <ModalFooter>
             <Button variant="flat" onPress={onExportClose}>
-              İptal
-        </Button>
-            <Button 
-              color="primary" 
-              onPress={handleExportSettings}
+              Cancel
+            </Button>
+            <Button
+              color="primary"
               isLoading={exporting}
+              onPress={handleExportSettings}
             >
-              Dışa Aktar
+              Export
             </Button>
           </ModalFooter>
         </ModalContent>
@@ -1435,24 +1769,24 @@ export default function SettingsPage() {
       {/* Import Modal */}
       <Modal isOpen={isImportOpen} onClose={onImportClose}>
         <ModalContent>
-          <ModalHeader>Ayarları İçe Aktar</ModalHeader>
+          <ModalHeader>Import Settings</ModalHeader>
           <ModalBody>
             <div className="space-y-4">
               <p>
-                Daha önce dışa aktardığınız ayar dosyasını seçin. 
-                Mevcut ayarlarınızın üzerine yazılacaktır.
+                Select the settings file you previously exported. Your existing
+                preferences will be overwritten.
               </p>
               <Input
-                type="file"
                 accept=".json"
+                label="Choose Settings File"
+                type="file"
                 onChange={handleImportSettings}
-                label="Ayar Dosyası Seç"
               />
-      </div>
+            </div>
           </ModalBody>
           <ModalFooter>
             <Button variant="flat" onPress={onImportClose}>
-              İptal
+              Cancel
             </Button>
           </ModalFooter>
         </ModalContent>
@@ -1461,16 +1795,17 @@ export default function SettingsPage() {
       {/* Reset Modal */}
       <Modal isOpen={isResetOpen} onClose={onResetClose}>
         <ModalContent>
-          <ModalHeader>Fabrika Ayarlarına Sıfırla</ModalHeader>
+          <ModalHeader>Reset to Factory Defaults</ModalHeader>
           <ModalBody>
             <div className="space-y-4">
               <div className="flex items-start space-x-3">
                 <AlertTriangle className="text-warning mt-1" size={20} />
                 <div>
-                  <p className="font-medium">Bu işlem geri alınamaz!</p>
+                  <p className="font-medium">This action cannot be undone!</p>
                   <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Tüm özelleştirilmiş ayarlarınız varsayılan değerlere sıfırlanacak.
-                    Profil bilgileriniz ve verileriniz etkilenmeyecek.
+                    All custom settings will be restored to their default
+                    values. Your profile information and data will remain
+                    intact.
                   </p>
                 </div>
               </div>
@@ -1478,52 +1813,56 @@ export default function SettingsPage() {
           </ModalBody>
           <ModalFooter>
             <Button variant="flat" onPress={onResetClose}>
-              İptal
+              Cancel
             </Button>
-            <Button 
-              color="danger" 
-              onPress={handleResetSettings}
-            >
-              Sıfırla
+            <Button color="danger" onPress={handleResetSettings}>
+              Reset
             </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>
 
       {/* About Modal */}
-      <Modal isOpen={isAboutOpen} onClose={onAboutClose} size="2xl">
+      <Modal isOpen={isAboutOpen} size="2xl" onClose={onAboutClose}>
         <ModalContent>
-          <ModalHeader>Yardım Merkezi</ModalHeader>
+          <ModalHeader>Help Center</ModalHeader>
           <ModalBody>
             <div className="space-y-6">
               <div>
-                <h4 className="font-semibold mb-2">Sık Sorulan Sorular</h4>
+                <h4 className="font-semibold mb-2">
+                  Frequently Asked Questions
+                </h4>
                 <Accordion>
-                  <AccordionItem key="1" title="Şifremi nasıl değiştirebilirim?">
-                    Güvenlik sekmesinden mevcut şifrenizi girip yeni şifre belirleyebilirsiniz.
+                  <AccordionItem key="1" title="How can I change my password?">
+                    Enter your current password on the Security tab and set a
+                    new one.
                   </AccordionItem>
-                  <AccordionItem key="2" title="Bildirimleri nasıl özelleştirebilirim?">
-                    Bildirimler sekmesinden hangi bildirimleri almak istediğinizi seçebilirsiniz.
+                  <AccordionItem
+                    key="2"
+                    title="How can I customize notifications?"
+                  >
+                    Choose the notifications you want to receive from the
+                    Notifications tab.
                   </AccordionItem>
-                  <AccordionItem key="3" title="Temayı nasıl değiştirebilirim?">
-                    Görünüm sekmesinden açık, koyu veya sistem temasını seçebilirsiniz.
+                  <AccordionItem key="3" title="How can I change the theme?">
+                    Select light, dark, or system theme from the Appearance tab.
                   </AccordionItem>
                 </Accordion>
               </div>
-              
+
               <div>
-                <h4 className="font-semibold mb-2">Klavye Kısayolları</h4>
+                <h4 className="font-semibold mb-2">Keyboard Shortcuts</h4>
                 <div className="space-y-2 text-sm">
                   <div className="flex justify-between">
-                    <span>Ayarları kaydet</span>
+                    <span>Save settings</span>
                     <Code size="sm">Ctrl + S</Code>
                   </div>
                   <div className="flex justify-between">
-                    <span>Arama</span>
+                    <span>Search</span>
                     <Code size="sm">Ctrl + K</Code>
                   </div>
                   <div className="flex justify-between">
-                    <span>Tema değiştir</span>
+                    <span>Toggle theme</span>
                     <Code size="sm">Ctrl + Shift + T</Code>
                   </div>
                 </div>
@@ -1531,9 +1870,7 @@ export default function SettingsPage() {
             </div>
           </ModalBody>
           <ModalFooter>
-            <Button onPress={onAboutClose}>
-              Kapat
-            </Button>
+            <Button onPress={onAboutClose}>Close</Button>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/client/app/dashboard/staff/page.tsx
+++ b/client/app/dashboard/staff/page.tsx
@@ -1,20 +1,51 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
-  Card, CardBody, Button, Input, Table, TableHeader, TableColumn, 
-  TableBody, TableRow, TableCell, Chip, Pagination, Modal, ModalContent, 
-  ModalHeader, ModalBody, ModalFooter, useDisclosure, Select, SelectItem
-} from '@heroui/react';
-import { DatePicker } from '@heroui/date-picker';
-import { parseDate } from '@internationalized/date';
-import { Edit, Trash2, Plus, Search, Users, Stethoscope, Shield, AlertTriangle } from 'lucide-react';
-import { useAuth } from '@/contexts/AuthContext';
-import { staffAPI, departmentsAPI } from '@/lib/api';
-import { Staff, Department, PermissionLevel } from '@/types';
-import { formatDate, getPermissionLevel, hasPermission, getErrorMessage, toDateString } from '@/lib/utils';
-import toast from 'react-hot-toast';
-import { useI18n } from '@/contexts/I18nContext';
+  Card,
+  CardBody,
+  Button,
+  Input,
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  Chip,
+  Pagination,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+  Select,
+  SelectItem,
+} from "@heroui/react";
+import { DatePicker } from "@heroui/date-picker";
+import { parseDate } from "@internationalized/date";
+import {
+  Edit,
+  Trash2,
+  Plus,
+  Search,
+  Shield,
+  AlertTriangle,
+} from "lucide-react";
+import toast from "react-hot-toast";
+
+import { useAuth } from "@/contexts/AuthContext";
+import { staffAPI, departmentsAPI } from "@/lib/api";
+import { Staff, Department, PermissionLevel } from "@/types";
+import {
+  formatDate,
+  getPermissionLevel,
+  hasPermission,
+  getErrorMessage,
+  toDateString,
+} from "@/lib/utils";
+import { useI18n } from "@/contexts/I18nContext";
 
 export default function StaffPage() {
   const { user } = useAuth();
@@ -22,10 +53,10 @@ export default function StaffPage() {
   const [staff, setStaff] = useState<Staff[]>([]);
   const [departments, setDepartments] = useState<Department[]>([]);
   const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [roleFilter, setRoleFilter] = useState('all');
-  const [statusFilter, setStatusFilter] = useState('all');
-  const [departmentFilter, setDepartmentFilter] = useState('all');
+  const [searchTerm, setSearchTerm] = useState("");
+  const [roleFilter, setRoleFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [departmentFilter, setDepartmentFilter] = useState("all");
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [selectedStaff, setSelectedStaff] = useState<Staff | null>(null);
@@ -42,116 +73,116 @@ export default function StaffPage() {
 
   // Form state for adding/editing staff
   const [formData, setFormData] = useState({
-    name: '',
-    role: '',
-    department_id: '',
-    email: '',
-    phone: '',
-    specialization: '',
-    hire_date: '',
-    salary: '',
-    status: 'active' as 'active' | 'inactive'
+    name: "",
+    role: "",
+    department_id: "",
+    email: "",
+    phone: "",
+    specialization: "",
+    hire_date: "",
+    salary: "",
+    status: "active" as "active" | "inactive",
   });
 
   // Mock data for demonstration
   const mockStaff: Staff[] = [
     {
-      staff_id: '1',
-      name: 'Dr. Sarah Wilson',
-      role: 'Doctor',
-      department_id: '1',
-      email: 'dr.sarah.wilson@hospital.com',
-      phone: '+1-555-0100',
-      specialization: 'Cardiology',
-      hire_date: '2020-01-15',
+      staff_id: "1",
+      name: "Dr. Sarah Wilson",
+      role: "Doctor",
+      department_id: "1",
+      email: "dr.sarah.wilson@hospital.com",
+      phone: "+1-555-0100",
+      specialization: "Cardiology",
+      hire_date: "2020-01-15",
       salary: 150000,
-      status: 'active',
-      created_at: '2020-01-15T09:00:00Z',
-      updated_at: '2024-01-15T09:00:00Z'
+      status: "active",
+      created_at: "2020-01-15T09:00:00Z",
+      updated_at: "2024-01-15T09:00:00Z",
     },
     {
-      staff_id: '2',
-      name: 'Dr. Michael Johnson',
-      role: 'Doctor',
-      department_id: '2',
-      email: 'dr.michael.johnson@hospital.com',
-      phone: '+1-555-0101',
-      specialization: 'Neurology',
-      hire_date: '2019-03-20',
+      staff_id: "2",
+      name: "Dr. Michael Johnson",
+      role: "Doctor",
+      department_id: "2",
+      email: "dr.michael.johnson@hospital.com",
+      phone: "+1-555-0101",
+      specialization: "Neurology",
+      hire_date: "2019-03-20",
       salary: 160000,
-      status: 'active',
-      created_at: '2019-03-20T09:00:00Z',
-      updated_at: '2024-01-15T09:00:00Z'
+      status: "active",
+      created_at: "2019-03-20T09:00:00Z",
+      updated_at: "2024-01-15T09:00:00Z",
     },
     {
-      staff_id: '3',
-      name: 'Nurse Emily Davis',
-      role: 'Nurse',
-      department_id: '1',
-      email: 'nurse.emily.davis@hospital.com',
-      phone: '+1-555-0102',
-      specialization: 'Emergency Care',
-      hire_date: '2021-06-10',
+      staff_id: "3",
+      name: "Nurse Emily Davis",
+      role: "Nurse",
+      department_id: "1",
+      email: "nurse.emily.davis@hospital.com",
+      phone: "+1-555-0102",
+      specialization: "Emergency Care",
+      hire_date: "2021-06-10",
       salary: 75000,
-      status: 'active',
-      created_at: '2021-06-10T09:00:00Z',
-      updated_at: '2024-01-15T09:00:00Z'
+      status: "active",
+      created_at: "2021-06-10T09:00:00Z",
+      updated_at: "2024-01-15T09:00:00Z",
     },
     {
-      staff_id: '4',
-      name: 'Dr. Robert Brown',
-      role: 'Doctor',
-      department_id: '3',
-      email: 'dr.robert.brown@hospital.com',
-      phone: '+1-555-0103',
-      specialization: 'Orthopedics',
-      hire_date: '2018-09-15',
+      staff_id: "4",
+      name: "Dr. Robert Brown",
+      role: "Doctor",
+      department_id: "3",
+      email: "dr.robert.brown@hospital.com",
+      phone: "+1-555-0103",
+      specialization: "Orthopedics",
+      hire_date: "2018-09-15",
       salary: 145000,
-      status: 'active',
-      created_at: '2018-09-15T09:00:00Z',
-      updated_at: '2024-01-15T09:00:00Z'
+      status: "active",
+      created_at: "2018-09-15T09:00:00Z",
+      updated_at: "2024-01-15T09:00:00Z",
     },
     {
-      staff_id: '5',
-      name: 'Admin Lisa Thompson',
-      role: 'Administrator',
-      department_id: '4',
-      email: 'admin.lisa.thompson@hospital.com',
-      phone: '+1-555-0104',
-      specialization: 'Hospital Administration',
-      hire_date: '2017-02-01',
+      staff_id: "5",
+      name: "Admin Lisa Thompson",
+      role: "Administrator",
+      department_id: "4",
+      email: "admin.lisa.thompson@hospital.com",
+      phone: "+1-555-0104",
+      specialization: "Hospital Administration",
+      hire_date: "2017-02-01",
       salary: 85000,
-      status: 'active',
-      created_at: '2017-02-01T09:00:00Z',
-      updated_at: '2024-01-15T09:00:00Z'
-    }
+      status: "active",
+      created_at: "2017-02-01T09:00:00Z",
+      updated_at: "2024-01-15T09:00:00Z",
+    },
   ];
 
   const mockDepartments: Department[] = [
     {
-      department_id: '1',
-      name: 'Cardiology',
-      description: 'Heart and cardiovascular care',
-      status: 'active'
+      department_id: "1",
+      name: "Cardiology",
+      description: "Heart and cardiovascular care",
+      status: "active",
     },
     {
-      department_id: '2',
-      name: 'Neurology',
-      description: 'Brain and nervous system care',
-      status: 'active'
+      department_id: "2",
+      name: "Neurology",
+      description: "Brain and nervous system care",
+      status: "active",
     },
     {
-      department_id: '3',
-      name: 'Orthopedics',
-      description: 'Bone and joint care',
-      status: 'active'
+      department_id: "3",
+      name: "Orthopedics",
+      description: "Bone and joint care",
+      status: "active",
     },
     {
-      department_id: '4',
-      name: 'Administration',
-      description: 'Hospital administration and management',
-      status: 'active'
-    }
+      department_id: "4",
+      name: "Administration",
+      description: "Hospital administration and management",
+      status: "active",
+    },
   ];
 
   useEffect(() => {
@@ -168,8 +199,9 @@ export default function StaffPage() {
 
   const loadStaff = async () => {
     if (!canViewStaff) {
-      setError(t('staff.no_permission_view'));
+      setError(t("staff.no_permission_view"));
       setLoading(false);
+
       return;
     }
 
@@ -181,18 +213,19 @@ export default function StaffPage() {
         page: currentPage,
         limit: 10,
         ...(searchTerm && { search: searchTerm }),
-        ...(roleFilter !== 'all' && { role: roleFilter }),
-        ...(statusFilter !== 'all' && { status: statusFilter }),
-        ...(departmentFilter !== 'all' && { department_id: departmentFilter }),
+        ...(roleFilter !== "all" && { role: roleFilter }),
+        ...(statusFilter !== "all" && { status: statusFilter }),
+        ...(departmentFilter !== "all" && { department_id: departmentFilter }),
       };
-      
+
       const response = await staffAPI.getAll(params);
-      console.log('Staff API response:', response.data);
-      
+
+      console.log("Staff API response:", response.data);
+
       // Handle backend response with pagination
       if (response.data?.data && Array.isArray(response.data.data)) {
         setStaff(response.data.data);
-        
+
         // Use backend pagination info if available
         if (response.data.pagination) {
           setTotalPages(response.data.pagination.totalPages);
@@ -202,49 +235,58 @@ export default function StaffPage() {
       } else {
         // Fallback to handling as array
         const staffData = Array.isArray(response.data) ? response.data : [];
+
         setStaff(staffData);
         setTotalPages(Math.ceil(staffData.length / 10));
       }
-      
     } catch (error) {
-      console.error('Failed to load staff:', error);
+      console.error("Failed to load staff:", error);
       setError(getErrorMessage(error));
       // Fallback to mock data if API fails
-      
+
       // Apply client-side filters to mock data for testing
       let filteredMockData = [...mockStaff];
-      
+
       if (searchTerm) {
-        filteredMockData = filteredMockData.filter((staffMember: Staff) => 
-          staffMember.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          staffMember.email?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          (staffMember.specialization?.toLowerCase().includes(searchTerm.toLowerCase()))
+        filteredMockData = filteredMockData.filter(
+          (staffMember: Staff) =>
+            staffMember.name
+              ?.toLowerCase()
+              .includes(searchTerm.toLowerCase()) ||
+            staffMember.email
+              ?.toLowerCase()
+              .includes(searchTerm.toLowerCase()) ||
+            staffMember.specialization
+              ?.toLowerCase()
+              .includes(searchTerm.toLowerCase()),
         );
       }
-      
-      if (roleFilter !== 'all') {
-        filteredMockData = filteredMockData.filter((staffMember: Staff) => 
-          staffMember.role?.toLowerCase() === roleFilter.toLowerCase()
+
+      if (roleFilter !== "all") {
+        filteredMockData = filteredMockData.filter(
+          (staffMember: Staff) =>
+            staffMember.role?.toLowerCase() === roleFilter.toLowerCase(),
         );
       }
-      
-      if (statusFilter !== 'all') {
-        filteredMockData = filteredMockData.filter((staffMember: Staff) => 
-          staffMember.status === statusFilter
+
+      if (statusFilter !== "all") {
+        filteredMockData = filteredMockData.filter(
+          (staffMember: Staff) => staffMember.status === statusFilter,
         );
       }
-      
-      if (departmentFilter !== 'all') {
-        filteredMockData = filteredMockData.filter((staffMember: Staff) => 
-          staffMember.department_id === departmentFilter
+
+      if (departmentFilter !== "all") {
+        filteredMockData = filteredMockData.filter(
+          (staffMember: Staff) =>
+            staffMember.department_id === departmentFilter,
         );
       }
-      
+
       // Apply pagination to mock data
       const startIndex = (currentPage - 1) * 10;
       const endIndex = startIndex + 10;
       const paginatedMockData = filteredMockData.slice(startIndex, endIndex);
-      
+
       setStaff(paginatedMockData);
       setTotalPages(Math.ceil(filteredMockData.length / 10));
     } finally {
@@ -255,12 +297,13 @@ export default function StaffPage() {
   const loadDepartments = async () => {
     try {
       const response = await departmentsAPI.getAll();
-      console.log('Departments API response:', response.data);
-      
+
+      console.log("Departments API response:", response.data);
+
       // Handle different response formats
       let departmentsData = [];
       const data = response.data;
-      
+
       if (Array.isArray(data)) {
         departmentsData = data;
       } else if (data && data.departments && Array.isArray(data.departments)) {
@@ -268,14 +311,14 @@ export default function StaffPage() {
       } else if (data && data.data && Array.isArray(data.data)) {
         departmentsData = data.data;
       } else {
-        console.warn('Unexpected departments response format:', data);
+        console.warn("Unexpected departments response format:", data);
         departmentsData = [];
       }
-      
-      console.log('Processed departments data:', departmentsData);
+
+      console.log("Processed departments data:", departmentsData);
       setDepartments(departmentsData);
     } catch (error) {
-      console.error('Failed to load departments:', error);
+      console.error("Failed to load departments:", error);
       // Fallback to mock data
       setDepartments(mockDepartments);
     }
@@ -283,51 +326,54 @@ export default function StaffPage() {
 
   const handleAddStaff = () => {
     if (!canManageStaff) {
-      toast.error(t('staff.no_permission_add'));
+      toast.error(t("staff.no_permission_add"));
+
       return;
     }
-    
+
     setIsAddMode(true);
     setSelectedStaff(null);
     setFormData({
-      name: '',
-      role: '',
-      department_id: '',
-      email: '',
-      phone: '',
-      specialization: '',
-      hire_date: '',
-      salary: '',
-      status: 'active'
+      name: "",
+      role: "",
+      department_id: "",
+      email: "",
+      phone: "",
+      specialization: "",
+      hire_date: "",
+      salary: "",
+      status: "active",
     });
     onOpen();
   };
 
   const handleEditStaff = (staffMember: Staff) => {
     if (!canEditStaff) {
-      toast.error(t('staff.no_permission_edit'));
+      toast.error(t("staff.no_permission_edit"));
+
       return;
     }
-    
+
     setIsAddMode(false);
     setSelectedStaff(staffMember);
     setFormData({
-      name: staffMember.name || '',
-      role: staffMember.role || '',
-      department_id: staffMember.department_id || '',
-      email: staffMember.email || '',
-      phone: staffMember.phone || '',
-      specialization: staffMember.specialization || '',
-      hire_date: staffMember.hire_date || '',
-      salary: staffMember.salary?.toString() || '',
-      status: staffMember.status || 'active'
+      name: staffMember.name || "",
+      role: staffMember.role || "",
+      department_id: staffMember.department_id || "",
+      email: staffMember.email || "",
+      phone: staffMember.phone || "",
+      specialization: staffMember.specialization || "",
+      hire_date: staffMember.hire_date || "",
+      salary: staffMember.salary?.toString() || "",
+      status: staffMember.status || "active",
     });
     onOpen();
   };
 
   const handleSubmit = async () => {
     if (!canEditStaff) {
-      toast.error(t('staff.no_permission_save'));
+      toast.error(t("staff.no_permission_save"));
+
       return;
     }
 
@@ -335,21 +381,23 @@ export default function StaffPage() {
     try {
       const submitData = {
         ...formData,
-        salary: formData.salary ? parseFloat(formData.salary) : undefined
+        salary: formData.salary ? parseFloat(formData.salary) : undefined,
       };
-      
+
       if (isAddMode) {
         await staffAPI.create(submitData);
-        toast.success(t('staff.staff_added'));
+        toast.success(t("staff.staff_added"));
       } else {
-        await staffAPI.update(selectedStaff!.staff_id || '', submitData);
-        toast.success(t('staff.staff_updated'));
+        await staffAPI.update(selectedStaff!.staff_id || "", submitData);
+        toast.success(t("staff.staff_updated"));
       }
       onClose();
       loadStaff();
     } catch (error) {
-      console.error('Failed to save staff member:', error);
-      toast.error(`${t('staff.save_error') || 'Failed to save staff member'}: ${getErrorMessage(error)}`);
+      console.error("Failed to save staff member:", error);
+      toast.error(
+        `${t("staff.save_error") || "Failed to save staff member"}: ${getErrorMessage(error)}`,
+      );
     } finally {
       setSubmitting(false);
     }
@@ -357,132 +405,179 @@ export default function StaffPage() {
 
   const handleDeleteStaff = async (staffId: string) => {
     if (!canManageStaff) {
-      toast.error(t('staff.no_permission_delete'));
+      toast.error(t("staff.no_permission_delete"));
+
       return;
     }
 
-    if (confirm(t('staff.delete_confirm') || 'Are you sure you want to delete this staff member?')) {
+    if (
+      confirm(
+        t("staff.delete_confirm") ||
+          "Are you sure you want to delete this staff member?",
+      )
+    ) {
       try {
         await staffAPI.delete(staffId);
-        toast.success(t('staff.staff_deleted'));
+        toast.success(t("staff.staff_deleted"));
         loadStaff();
       } catch (error) {
-        console.error('Failed to delete staff member:', error);
-        toast.error(`${t('staff.delete_error') || 'Failed to delete staff member'}: ${getErrorMessage(error)}`);
+        console.error("Failed to delete staff member:", error);
+        toast.error(
+          `${t("staff.delete_error") || "Failed to delete staff member"}: ${getErrorMessage(error)}`,
+        );
       }
     }
   };
 
-
-
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'active': return 'success';
-      case 'inactive': return 'danger';
-      default: return 'default';
+      case "active":
+        return "success";
+      case "inactive":
+        return "danger";
+      default:
+        return "default";
     }
   };
 
   const getRoleColor = (role: string) => {
     switch (role.toLowerCase()) {
-      case 'doctor': return 'primary';
-      case 'nurse': return 'secondary';
-      case 'administrator': 
-      case 'admin': return 'warning';
-      case 'technician': return 'success';
-      case 'pharmacist': return 'secondary';
-      case 'receptionist': return 'default';
-      default: return 'default';
+      case "doctor":
+        return "primary";
+      case "nurse":
+        return "secondary";
+      case "administrator":
+      case "admin":
+        return "warning";
+      case "technician":
+        return "success";
+      case "pharmacist":
+        return "secondary";
+      case "receptionist":
+        return "default";
+      default:
+        return "default";
     }
   };
 
   const getRoleDisplayName = (role: string) => {
     const normalizedRole = role.toLowerCase();
+
     return t(`staff.roles.${normalizedRole}`) || role;
   };
 
   const getDepartmentName = (departmentId: string | any) => {
-    console.log('getDepartmentName called with:', { departmentId, type: typeof departmentId });
-    
+    console.log("getDepartmentName called with:", {
+      departmentId,
+      type: typeof departmentId,
+    });
+
     if (!departmentId || !Array.isArray(departments)) {
-      console.log('Early return: no departmentId or departments not array');
-      return 'Unknown Department';
+      console.log("Early return: no departmentId or departments not array");
+
+      return "Unknown Department";
     }
-    
+
     // If departmentId is already populated object with name
-    if (typeof departmentId === 'object' && departmentId.name) {
-      console.log('Found populated department:', departmentId.name);
+    if (typeof departmentId === "object" && departmentId.name) {
+      console.log("Found populated department:", departmentId.name);
+
       return departmentId.name;
     }
-    
+
     // Extract string ID from object or use as string
-    const idString = typeof departmentId === 'object' ? departmentId._id || departmentId.department_id : departmentId;
-    console.log('Looking for department with ID:', idString);
-    
+    const idString =
+      typeof departmentId === "object"
+        ? departmentId._id || departmentId.department_id
+        : departmentId;
+
+    console.log("Looking for department with ID:", idString);
+
     // Try both _id and department_id fields for compatibility
-    const department = departments.find(d => 
-      d._id === idString || 
-      d.department_id === idString
+    const department = departments.find(
+      (d) => d._id === idString || d.department_id === idString,
     );
-    
-    console.log('Found department:', department);
-    return department?.name || 'Unknown Department';
+
+    console.log("Found department:", department);
+
+    return department?.name || "Unknown Department";
   };
 
   const renderCell = (staffMember: Staff, columnKey: string) => {
     switch (columnKey) {
-      case 'name':
+      case "name":
         return (
           <div>
             <p className="font-medium">{staffMember.name}</p>
             <p className="text-sm text-gray-500">{staffMember.email}</p>
           </div>
         );
-      case 'role':
+      case "role":
         return (
-          <Chip color={getRoleColor(staffMember.role || '')} size="sm">
-            {getRoleDisplayName(staffMember.role || 'Unknown')}
+          <Chip color={getRoleColor(staffMember.role || "")} size="sm">
+            {getRoleDisplayName(staffMember.role || "Unknown")}
           </Chip>
         );
-      case 'department':
+      case "department":
         // Handle both department_id and departmentId fields
-        const deptId = staffMember.department_id || (staffMember as any).departmentId;
+        const deptId =
+          staffMember.department_id || (staffMember as any).departmentId;
+
         return getDepartmentName(deptId);
-      case 'contact':
+      case "contact":
         return (
           <div>
             <p>{staffMember.phone}</p>
-            <p className="text-sm text-gray-500">{staffMember.specialization}</p>
+            <p className="text-sm text-gray-500">
+              {staffMember.specialization}
+            </p>
           </div>
         );
-      case 'hire_date':
-        return staffMember.hire_date ? formatDate(staffMember.hire_date) : 'N/A';
-      case 'salary':
-        return staffMember.salary ? `$${staffMember.salary.toLocaleString()}` : 'N/A';
-      case 'status':
+      case "hire_date":
+        return staffMember.hire_date
+          ? formatDate(staffMember.hire_date)
+          : "N/A";
+      case "salary":
+        return staffMember.salary
+          ? `$${staffMember.salary.toLocaleString()}`
+          : "N/A";
+      case "status":
         return (
-          <Chip color={getStatusColor(staffMember.status || 'active')} size="sm">
-            {staffMember.status || 'Active'}
+          <Chip
+            color={getStatusColor(staffMember.status || "active")}
+            size="sm"
+          >
+            {staffMember.status || "Active"}
           </Chip>
         );
-      case 'actions':
+      case "actions":
         return (
           <div className="flex gap-2">
             {canEditStaff && (
-              <Button size="sm" color="primary" variant="flat" onPress={() => handleEditStaff(staffMember)}>
+              <Button
+                color="primary"
+                size="sm"
+                variant="flat"
+                onPress={() => handleEditStaff(staffMember)}
+              >
                 <Edit size={16} />
               </Button>
             )}
             {/* Status change removed - only show current status */}
             {canManageStaff && (
-              <Button size="sm" color="danger" variant="flat" onPress={() => handleDeleteStaff(staffMember.staff_id || '')}>
+              <Button
+                color="danger"
+                size="sm"
+                variant="flat"
+                onPress={() => handleDeleteStaff(staffMember.staff_id || "")}
+              >
                 <Trash2 size={16} />
               </Button>
             )}
             {!canEditStaff && (
-              <Chip size="sm" color="warning" variant="flat">
-                <Shield size={12} className="mr-1" />
-                {t('staff.view_only_access')}
+              <Chip color="warning" size="sm" variant="flat">
+                <Shield className="mr-1" size={12} />
+                {t("staff.view_only_access")}
               </Chip>
             )}
           </div>
@@ -493,27 +588,33 @@ export default function StaffPage() {
   };
 
   const columns = [
-    { key: 'name', label: t('staff.name_email') || 'Name & Email' },
-    { key: 'role', label: t('staff.role') || 'Role' },
-    { key: 'department', label: t('staff.department') || 'Department' },
-    { key: 'contact', label: t('staff.contact_specialization') || 'Contact & Specialization' },
-    { key: 'hire_date', label: t('staff.hire_date') || 'Hire Date' },
-    { key: 'salary', label: t('staff.salary') || 'Salary' },
-    { key: 'status', label: t('staff.status') || 'Status' },
-    { key: 'actions', label: t('staff.actions') || 'Actions' }
+    { key: "name", label: t("staff.name_email") || "Name & Email" },
+    { key: "role", label: t("staff.role") || "Role" },
+    { key: "department", label: t("staff.department") || "Department" },
+    {
+      key: "contact",
+      label: t("staff.contact_specialization") || "Contact & Specialization",
+    },
+    { key: "hire_date", label: t("staff.hire_date") || "Hire Date" },
+    { key: "salary", label: t("staff.salary") || "Salary" },
+    { key: "status", label: t("staff.status") || "Status" },
+    { key: "actions", label: t("staff.actions") || "Actions" },
   ];
 
   // Permission check for page access
   if (!canViewStaff) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[400px] space-y-4">
-        <AlertTriangle size={64} className="text-warning" />
-        <h2 className="text-2xl font-bold text-foreground">{t('staff.access_denied')}</h2>
+        <AlertTriangle className="text-warning" size={64} />
+        <h2 className="text-2xl font-bold text-foreground">
+          {t("staff.access_denied")}
+        </h2>
         <p className="text-muted-foreground text-center max-w-md">
-          {t('staff.no_permission_message')}
+          {t("staff.no_permission_message")}
         </p>
         <Chip color="warning" variant="flat">
-          {t('staff.required_permission')}: {PermissionLevel.NURSE} ({t('staff.roles.nurse')}) {t('staff.or_higher')}
+          {t("staff.required_permission")}: {PermissionLevel.NURSE} (
+          {t("staff.roles.nurse")}) {t("staff.or_higher")}
         </Chip>
       </div>
     );
@@ -525,19 +626,24 @@ export default function StaffPage() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-            {t('staff.title')}
+            {t("staff.title")}
           </h1>
           <p className="text-gray-600 dark:text-gray-400 mt-1">
-            {t('staff.subtitle')}
+            {t("staff.subtitle")}
           </p>
           <div className="flex items-center gap-2 mt-2">
-            <Chip size="sm" color="primary" variant="flat">
-              <Shield size={12} className="mr-1" />
-              {t('staff.your_role')}: {getPermissionLevel(user) === 3 ? t('staff.roles.administrator') : getPermissionLevel(user) === 2 ? t('staff.roles.doctor') : t('staff.roles.nurse')}
+            <Chip color="primary" size="sm" variant="flat">
+              <Shield className="mr-1" size={12} />
+              {t("staff.your_role")}:{" "}
+              {getPermissionLevel(user) === 3
+                ? t("staff.roles.administrator")
+                : getPermissionLevel(user) === 2
+                  ? t("staff.roles.doctor")
+                  : t("staff.roles.nurse")}
             </Chip>
             {!canEditStaff && (
-              <Chip size="sm" color="warning" variant="flat">
-                {t('staff.view_only_access')}
+              <Chip color="warning" size="sm" variant="flat">
+                {t("staff.view_only_access")}
               </Chip>
             )}
           </div>
@@ -545,7 +651,7 @@ export default function StaffPage() {
         {canManageStaff && (
           <Button color="primary" onPress={handleAddStaff}>
             <Plus className="mr-2" size={20} />
-            {t('staff.add_staff')}
+            {t("staff.add_staff")}
           </Button>
         )}
       </div>
@@ -568,87 +674,124 @@ export default function StaffPage() {
           <div className="flex flex-col gap-4">
             <div className="flex flex-col sm:flex-row gap-4">
               <Input
-                placeholder={t("staff.search_placeholder") || "Search staff by name, email, or specialization..."}
+                isClearable
+                className="flex-1"
+                placeholder={
+                  t("staff.search_placeholder") ||
+                  "Search staff by name, email, or specialization..."
+                }
+                startContent={<Search size={16} />}
                 value={searchTerm}
                 onValueChange={setSearchTerm}
-                className="flex-1"
-                startContent={<Search size={16} />}
-                isClearable
               />
-              
+
               <Select
+                className="sm:w-48"
                 label={t("staff.role") || "Role"}
                 placeholder={t("staff.select_role") || "Select role"}
-                className="sm:w-48"
-                selectedKeys={roleFilter !== 'all' ? [roleFilter] : []}
+                selectedKeys={roleFilter !== "all" ? [roleFilter] : []}
+                variant="bordered"
                 onSelectionChange={(keys) => {
                   const selectedKey = Array.from(keys)[0] as string;
-                  setRoleFilter(selectedKey || 'all');
+
+                  setRoleFilter(selectedKey || "all");
                 }}
-                variant="bordered"
               >
                 <SelectItem key="all">{t("staff.all_roles")}</SelectItem>
-                <SelectItem key="doctor">{getRoleDisplayName("doctor")}</SelectItem>
-                <SelectItem key="nurse">{getRoleDisplayName("nurse")}</SelectItem>
-                <SelectItem key="technician">{getRoleDisplayName("technician")}</SelectItem>
-                <SelectItem key="administrator">{getRoleDisplayName("administrator")}</SelectItem>
-                <SelectItem key="admin">{getRoleDisplayName("admin")}</SelectItem>
-                <SelectItem key="pharmacist">{getRoleDisplayName("pharmacist")}</SelectItem>
-                <SelectItem key="receptionist">{getRoleDisplayName("receptionist")}</SelectItem>
+                <SelectItem key="doctor">
+                  {getRoleDisplayName("doctor")}
+                </SelectItem>
+                <SelectItem key="nurse">
+                  {getRoleDisplayName("nurse")}
+                </SelectItem>
+                <SelectItem key="technician">
+                  {getRoleDisplayName("technician")}
+                </SelectItem>
+                <SelectItem key="administrator">
+                  {getRoleDisplayName("administrator")}
+                </SelectItem>
+                <SelectItem key="admin">
+                  {getRoleDisplayName("admin")}
+                </SelectItem>
+                <SelectItem key="pharmacist">
+                  {getRoleDisplayName("pharmacist")}
+                </SelectItem>
+                <SelectItem key="receptionist">
+                  {getRoleDisplayName("receptionist")}
+                </SelectItem>
               </Select>
-              
+
               <Select
-                label={t("staff.department") || "Department"}
-                placeholder={t("staff.select_department") || "Select department"}
                 className="sm:w-48"
-                selectedKeys={departmentFilter !== 'all' ? [departmentFilter] : []}
+                label={t("staff.department") || "Department"}
+                placeholder={
+                  t("staff.select_department") || "Select department"
+                }
+                selectedKeys={
+                  departmentFilter !== "all" ? [departmentFilter] : []
+                }
+                variant="bordered"
                 onSelectionChange={(keys) => {
                   const selectedKey = Array.from(keys)[0] as string;
-                  setDepartmentFilter(selectedKey || 'all');
+
+                  setDepartmentFilter(selectedKey || "all");
                 }}
-                variant="bordered"
               >
                 <SelectItem key="all">{t("staff.all_departments")}</SelectItem>
                 <>
-                                  {Array.isArray(departments) ? departments.map((dept) => (
-                  <SelectItem key={dept._id || dept.department_id || Math.random().toString()}>
-                    {dept.name || 'Unknown Department'}
-                  </SelectItem>
-                )) : (
-                  <SelectItem key="none" isDisabled>{t('staff.no_departments_available')}</SelectItem>
-                )}
+                  {Array.isArray(departments) ? (
+                    departments.map((dept) => (
+                      <SelectItem
+                        key={
+                          dept._id ||
+                          dept.department_id ||
+                          Math.random().toString()
+                        }
+                      >
+                        {dept.name || "Unknown Department"}
+                      </SelectItem>
+                    ))
+                  ) : (
+                    <SelectItem key="none" isDisabled>
+                      {t("staff.no_departments_available")}
+                    </SelectItem>
+                  )}
                 </>
               </Select>
-              
+
               <Select
+                className="sm:w-48"
                 label={t("staff.status")}
                 placeholder={t("staff.select_status")}
-                className="sm:w-48"
-                selectedKeys={statusFilter !== 'all' ? [statusFilter] : []}
+                selectedKeys={statusFilter !== "all" ? [statusFilter] : []}
+                variant="bordered"
                 onSelectionChange={(keys) => {
                   const selectedKey = Array.from(keys)[0] as string;
-                  setStatusFilter(selectedKey || 'all');
+
+                  setStatusFilter(selectedKey || "all");
                 }}
-                variant="bordered"
               >
                 <SelectItem key="all">{t("staff.all_status")}</SelectItem>
                 <SelectItem key="active">{t("staff.active")}</SelectItem>
                 <SelectItem key="inactive">{t("staff.inactive")}</SelectItem>
               </Select>
             </div>
-            
+
             {/* Clear Filters Button */}
-            {(searchTerm || roleFilter !== 'all' || departmentFilter !== 'all' || statusFilter !== 'all') && (
+            {(searchTerm ||
+              roleFilter !== "all" ||
+              departmentFilter !== "all" ||
+              statusFilter !== "all") && (
               <div className="flex justify-end">
                 <Button
-                  variant="flat"
                   color="default"
                   size="sm"
+                  variant="flat"
                   onPress={() => {
-                    setSearchTerm('');
-                    setRoleFilter('all');
-                    setDepartmentFilter('all');
-                    setStatusFilter('all');
+                    setSearchTerm("");
+                    setRoleFilter("all");
+                    setDepartmentFilter("all");
+                    setStatusFilter("all");
                   }}
                 >
                   {t("common.clear_filters")}
@@ -668,7 +811,7 @@ export default function StaffPage() {
                 <TableColumn key={column.key}>{column.label}</TableColumn>
               ))}
             </TableHeader>
-            <TableBody emptyContent={t('staff.no_staff')}>
+            <TableBody emptyContent={t("staff.no_staff")}>
               {staff.map((staffMember) => (
                 <TableRow key={staffMember.staff_id}>
                   {columns.map((column) => (
@@ -680,12 +823,12 @@ export default function StaffPage() {
               ))}
             </TableBody>
           </Table>
-          
+
           {staff.length > 0 && (
             <div className="flex justify-center p-4">
               <Pagination
-                total={totalPages}
                 page={currentPage}
+                total={totalPages}
                 onChange={setCurrentPage}
               />
             </div>
@@ -694,7 +837,12 @@ export default function StaffPage() {
       </Card>
 
       {/* Add/Edit Staff Modal */}
-      <Modal isOpen={isOpen} onClose={onClose} size="2xl" scrollBehavior="inside">
+      <Modal
+        isOpen={isOpen}
+        scrollBehavior="inside"
+        size="2xl"
+        onClose={onClose}
+      >
         <ModalContent>
           <ModalHeader>
             {isAddMode ? t("staff.add_staff") : t("staff.edit_staff")}
@@ -702,108 +850,158 @@ export default function StaffPage() {
           <ModalBody>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <Input
+                isRequired
                 label={t("staff.name") || "Full Name"}
                 placeholder={t("staff.enter_name") || "Enter name"}
                 value={formData.name}
-                onChange={(e) => setFormData({...formData, name: e.target.value})}
-                isRequired
+                onChange={(e) =>
+                  setFormData({ ...formData, name: e.target.value })
+                }
               />
-              
+
               <Select
+                isRequired
+                isDisabled={!canManageStaff}
                 label={t("staff.role") || "Role"}
                 placeholder={t("staff.select_role") || "Select a role"}
                 selectedKeys={formData.role ? [formData.role] : []}
                 onSelectionChange={(keys) => {
                   const selectedKey = Array.from(keys)[0] as string;
-                  setFormData({...formData, role: selectedKey});
+
+                  setFormData({ ...formData, role: selectedKey });
                 }}
-                isRequired
-                isDisabled={!canManageStaff}
               >
-                <SelectItem key="doctor">{getRoleDisplayName("doctor")}</SelectItem>
-                <SelectItem key="nurse">{getRoleDisplayName("nurse")}</SelectItem>
-                <SelectItem key="administrator">{getRoleDisplayName("administrator")}</SelectItem>
-                <SelectItem key="technician">{getRoleDisplayName("technician")}</SelectItem>
-                <SelectItem key="pharmacist">{getRoleDisplayName("pharmacist")}</SelectItem>
-                <SelectItem key="receptionist">{getRoleDisplayName("receptionist")}</SelectItem>
+                <SelectItem key="doctor">
+                  {getRoleDisplayName("doctor")}
+                </SelectItem>
+                <SelectItem key="nurse">
+                  {getRoleDisplayName("nurse")}
+                </SelectItem>
+                <SelectItem key="administrator">
+                  {getRoleDisplayName("administrator")}
+                </SelectItem>
+                <SelectItem key="technician">
+                  {getRoleDisplayName("technician")}
+                </SelectItem>
+                <SelectItem key="pharmacist">
+                  {getRoleDisplayName("pharmacist")}
+                </SelectItem>
+                <SelectItem key="receptionist">
+                  {getRoleDisplayName("receptionist")}
+                </SelectItem>
               </Select>
-              
+
               <Select
+                isRequired
                 label={t("staff.department") || "Department"}
-                placeholder={t("staff.select_department") || "Select a department"}
-                selectedKeys={formData.department_id ? [formData.department_id] : []}
+                placeholder={
+                  t("staff.select_department") || "Select a department"
+                }
+                selectedKeys={
+                  formData.department_id ? [formData.department_id] : []
+                }
                 onSelectionChange={(keys) => {
                   const selectedKey = Array.from(keys)[0] as string;
-                  setFormData({...formData, department_id: selectedKey});
+
+                  setFormData({ ...formData, department_id: selectedKey });
                 }}
-                isRequired
               >
                 <>
-                  {Array.isArray(departments) ? departments.map((department) => (
-                    <SelectItem key={department._id || department.department_id || Math.random().toString()}>
-                      {department.name || 'Unknown Department'}
+                  {Array.isArray(departments) ? (
+                    departments.map((department) => (
+                      <SelectItem
+                        key={
+                          department._id ||
+                          department.department_id ||
+                          Math.random().toString()
+                        }
+                      >
+                        {department.name || "Unknown Department"}
+                      </SelectItem>
+                    ))
+                  ) : (
+                    <SelectItem key="none" isDisabled>
+                      {t("staff.no_departments_available")}
                     </SelectItem>
-                  )                  ) : (
-                    <SelectItem key="none" isDisabled>{t('staff.no_departments_available')}</SelectItem>
                   )}
                 </>
               </Select>
-              
+
               <Input
-                label={t("staff.email") || "Email"}
-                type="email"
-                placeholder={t("staff.enter_email") || "Enter email"}
-                value={formData.email}
-                onChange={(e) => setFormData({...formData, email: e.target.value})}
                 isRequired
+                label={t("staff.email") || "Email"}
+                placeholder={t("staff.enter_email") || "Enter email"}
+                type="email"
+                value={formData.email}
+                onChange={(e) =>
+                  setFormData({ ...formData, email: e.target.value })
+                }
               />
-              
+
               <Input
+                isRequired
                 label={t("staff.phone") || "Phone"}
                 placeholder={t("staff.enter_phone") || "Enter phone"}
                 value={formData.phone}
-                onChange={(e) => setFormData({...formData, phone: e.target.value})}
-                isRequired
+                onChange={(e) =>
+                  setFormData({ ...formData, phone: e.target.value })
+                }
               />
-              
+
               <Input
                 label={t("staff.specialization") || "Specialization"}
-                placeholder={t("staff.enter_specialization") || "Enter specialization"}
+                placeholder={
+                  t("staff.enter_specialization") || "Enter specialization"
+                }
                 value={formData.specialization}
-                onChange={(e) => setFormData({...formData, specialization: e.target.value})}
+                onChange={(e) =>
+                  setFormData({ ...formData, specialization: e.target.value })
+                }
               />
-              
+
               <DatePicker
-                label={t("staff.hire_date") || "Hire Date"}
-                value={formData.hire_date ? parseDate(toDateString(formData.hire_date) || '') : null}
-                onChange={(value: any) => {
-                  const dateString = value ? value.toString() : '';
-                  setFormData({...formData, hire_date: dateString});
-                }}
                 isRequired
-                description={t('staff.hire_date_description') || "Employee's hire date"}
                 className="w-full"
+                description={
+                  t("staff.hire_date_description") || "Employee's hire date"
+                }
+                label={t("staff.hire_date") || "Hire Date"}
+                value={
+                  formData.hire_date
+                    ? parseDate(toDateString(formData.hire_date) || "")
+                    : null
+                }
+                onChange={(value: any) => {
+                  const dateString = value ? value.toString() : "";
+
+                  setFormData({ ...formData, hire_date: dateString });
+                }}
               />
-              
+
               <Input
                 label={t("staff.salary") || "Salary"}
-                type="number"
                 placeholder={t("staff.enter_salary") || "Enter salary"}
+                startContent={<span>$</span>}
+                type="number"
                 value={formData.salary}
                 onChange={(e) => {
                   // Sadece rakam ve nokta karakterine izin ver
-                  const value = e.target.value.replace(/[^0-9.]/g, '');
-                  setFormData({...formData, salary: value});
+                  const value = e.target.value.replace(/[^0-9.]/g, "");
+
+                  setFormData({ ...formData, salary: value });
                 }}
-                startContent={<span>$</span>}
               />
-              
+
               <Select
                 label={t("staff.status")}
                 selectedKeys={[formData.status]}
                 onSelectionChange={(keys) => {
                   const selectedKey = Array.from(keys)[0] as string;
-                  setFormData({...formData, status: selectedKey as 'active' | 'inactive'});
+
+                  setFormData({
+                    ...formData,
+                    status: selectedKey as "active" | "inactive",
+                  });
                 }}
               >
                 <SelectItem key="active">{t("staff.active")}</SelectItem>
@@ -812,10 +1010,14 @@ export default function StaffPage() {
             </div>
           </ModalBody>
           <ModalFooter>
-            <Button variant="flat" onPress={onClose} isDisabled={submitting}>
+            <Button isDisabled={submitting} variant="flat" onPress={onClose}>
               {t("staff.cancel")}
             </Button>
-            <Button color="primary" onPress={handleSubmit} isLoading={submitting}>
+            <Button
+              color="primary"
+              isLoading={submitting}
+              onPress={handleSubmit}
+            >
               {isAddMode ? t("staff.add_staff") : t("staff.update")}
             </Button>
           </ModalFooter>

--- a/client/components/CommandPalette.tsx
+++ b/client/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import {
   Modal,
   ModalContent,
@@ -12,7 +12,6 @@ import {
   Divider,
 } from "@heroui/react";
 import { useRouter } from "next/navigation";
-import { useI18n } from "@/contexts/I18nContext";
 import {
   Search,
   Users,
@@ -30,9 +29,10 @@ import {
   Moon,
   Monitor,
   LogOut,
-  User,
   ArrowRight,
 } from "lucide-react";
+
+import { useI18n } from "@/contexts/I18nContext";
 
 interface CommandItem {
   id: string;
@@ -57,15 +57,27 @@ interface CommandPaletteProps {
 export default function CommandPalette({
   isOpen,
   onClose,
-  user,
+  user: _user,
   onLogout,
   onThemeChange,
   theme,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const { t } = useI18n();
+
+  useEffect(() => {
+    if (isOpen) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    } else {
+      setQuery("");
+      setSelectedIndex(0);
+    }
+  }, [isOpen]);
 
   const commands: CommandItem[] = useMemo(
     () => [
@@ -77,7 +89,7 @@ export default function CommandPalette({
         icon: <Home size={18} />,
         action: () => router.push("/dashboard"),
         category: "navigation",
-        keywords: ["dashboard", "home", "main", "ana sayfa"],
+        keywords: ["dashboard", "home", "main"],
         shortcut: "Ctrl+H",
       },
       {
@@ -87,7 +99,7 @@ export default function CommandPalette({
         icon: <Users size={18} />,
         action: () => router.push("/dashboard/patients"),
         category: "navigation",
-        keywords: ["patients", "hasta", "hastalar", "people"],
+        keywords: ["patients", "people", "records"],
       },
       {
         id: "nav-appointments",
@@ -96,7 +108,7 @@ export default function CommandPalette({
         icon: <Calendar size={18} />,
         action: () => router.push("/dashboard/appointments"),
         category: "navigation",
-        keywords: ["appointments", "randevu", "calendar", "schedule"],
+        keywords: ["appointments", "calendar", "schedule", "booking"],
       },
       {
         id: "nav-alerts",
@@ -105,7 +117,7 @@ export default function CommandPalette({
         icon: <Bell size={18} />,
         action: () => router.push("/dashboard/alerts"),
         category: "navigation",
-        keywords: ["alerts", "notifications", "uyarılar", "bildirimler"],
+        keywords: ["alerts", "notifications", "reminders"],
       },
       {
         id: "nav-tests",
@@ -114,7 +126,7 @@ export default function CommandPalette({
         icon: <Activity size={18} />,
         action: () => router.push("/dashboard/tests"),
         category: "navigation",
-        keywords: ["tests", "testler", "medical", "results", "sonuçlar"],
+        keywords: ["tests", "labs", "medical", "results"],
       },
       {
         id: "nav-staff",
@@ -123,14 +135,7 @@ export default function CommandPalette({
         icon: <Stethoscope size={18} />,
         action: () => router.push("/dashboard/staff"),
         category: "navigation",
-        keywords: [
-          "staff",
-          "personel",
-          "doctors",
-          "nurses",
-          "doktor",
-          "hemşire",
-        ],
+        keywords: ["staff", "team", "doctors", "nurses"],
       },
       {
         id: "nav-departments",
@@ -139,7 +144,7 @@ export default function CommandPalette({
         icon: <Building2 size={18} />,
         action: () => router.push("/dashboard/departments"),
         category: "navigation",
-        keywords: ["departments", "bölümler", "units", "birimler"],
+        keywords: ["departments", "units", "teams", "divisions"],
       },
       {
         id: "nav-rooms",
@@ -148,7 +153,7 @@ export default function CommandPalette({
         icon: <Bed size={18} />,
         action: () => router.push("/dashboard/rooms"),
         category: "navigation",
-        keywords: ["rooms", "odalar", "beds", "yataklar"],
+        keywords: ["rooms", "wards", "beds", "capacity"],
       },
       {
         id: "nav-records",
@@ -157,7 +162,7 @@ export default function CommandPalette({
         icon: <FileText size={18} />,
         action: () => router.push("/dashboard/medical-records"),
         category: "navigation",
-        keywords: ["records", "kayıtlar", "medical", "tıbbi", "files"],
+        keywords: ["records", "medical", "files", "history"],
       },
       {
         id: "nav-inventory",
@@ -166,7 +171,7 @@ export default function CommandPalette({
         icon: <Package size={18} />,
         action: () => router.push("/dashboard/inventory"),
         category: "navigation",
-        keywords: ["inventory", "envanter", "supplies", "malzemeler"],
+        keywords: ["inventory", "supplies", "stock", "equipment"],
       },
       {
         id: "nav-settings",
@@ -175,7 +180,7 @@ export default function CommandPalette({
         icon: <Settings size={18} />,
         action: () => router.push("/dashboard/settings"),
         category: "settings",
-        keywords: ["settings", "ayarlar", "preferences", "config"],
+        keywords: ["settings", "preferences", "configuration", "options"],
         shortcut: "Ctrl+,",
       },
 
@@ -194,7 +199,7 @@ export default function CommandPalette({
           ),
         action: onThemeChange,
         category: "actions",
-        keywords: ["theme", "tema", "dark", "light", "karanlık", "aydınlık"],
+        keywords: ["theme", "appearance", "dark", "light", "display"],
         shortcut: "Ctrl+T",
       },
       {
@@ -204,7 +209,7 @@ export default function CommandPalette({
         icon: <LogOut size={18} />,
         action: onLogout,
         category: "actions",
-        keywords: ["logout", "çıkış", "sign out", "exit"],
+        keywords: ["logout", "sign out", "exit", "signoff"],
         shortcut: "Ctrl+Q",
       },
 
@@ -219,8 +224,9 @@ export default function CommandPalette({
           // Focus search input after navigation
           setTimeout(() => {
             const searchInput = document.querySelector(
-              'input[placeholder*="patient"]'
+              'input[placeholder*="patient"]',
             ) as HTMLInputElement;
+
             if (searchInput) searchInput.focus();
           }, 100);
         },
@@ -237,8 +243,9 @@ export default function CommandPalette({
           router.push("/dashboard/appointments");
           setTimeout(() => {
             const searchInput = document.querySelector(
-              'input[placeholder*="appointment"]'
+              'input[placeholder*="appointment"]',
             ) as HTMLInputElement;
+
             if (searchInput) searchInput.focus();
           }, 100);
         },
@@ -247,31 +254,34 @@ export default function CommandPalette({
         shortcut: "Ctrl+A",
       },
     ],
-    [router, t, theme, onThemeChange, onLogout]
+    [router, t, theme, onThemeChange, onLogout],
   );
 
   const filteredCommands = useMemo(() => {
     if (!query.trim()) return commands;
 
     const searchTerm = query.toLowerCase().trim();
+
     return commands.filter(
       (command) =>
         command.title.toLowerCase().includes(searchTerm) ||
         command.description?.toLowerCase().includes(searchTerm) ||
         command.keywords.some((keyword) =>
-          keyword.toLowerCase().includes(searchTerm)
-        )
+          keyword.toLowerCase().includes(searchTerm),
+        ),
     );
   }, [commands, query]);
 
   const groupedCommands = useMemo(() => {
     const groups: Record<string, CommandItem[]> = {};
+
     filteredCommands.forEach((command) => {
       if (!groups[command.category]) {
         groups[command.category] = [];
       }
       groups[command.category].push(command);
     });
+
     return groups;
   }, [filteredCommands]);
 
@@ -295,13 +305,13 @@ export default function CommandPalette({
       case "ArrowDown":
         e.preventDefault();
         setSelectedIndex((prev) =>
-          prev < allFilteredCommands.length - 1 ? prev + 1 : 0
+          prev < allFilteredCommands.length - 1 ? prev + 1 : 0,
         );
         break;
       case "ArrowUp":
         e.preventDefault();
         setSelectedIndex((prev) =>
-          prev > 0 ? prev - 1 : allFilteredCommands.length - 1
+          prev > 0 ? prev - 1 : allFilteredCommands.length - 1,
         );
         break;
       case "Enter":
@@ -351,37 +361,37 @@ export default function CommandPalette({
 
   return (
     <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      size="2xl"
-      placement="top"
       classNames={{
         backdrop: "bg-black/50 backdrop-blur-sm",
         base: "mt-16",
         wrapper: "items-start",
       }}
+      isOpen={isOpen}
+      placement="top"
+      size="2xl"
+      onClose={onClose}
     >
       <ModalContent>
         <ModalHeader className="pb-2">
           <div className="flex items-center space-x-2 w-full">
-            <Search size={20} className="text-muted-foreground" />
+            <Search className="text-muted-foreground" size={20} />
             <span className="font-semibold">{t("command_palette.title")}</span>
           </div>
         </ModalHeader>
         <ModalBody className="pb-6">
           <Input
-            placeholder={t("command_palette.placeholder")}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            autoFocus
-            startContent={
-              <Search size={18} className="text-muted-foreground" />
-            }
+            ref={inputRef}
             classNames={{
               inputWrapper: "border-divider",
               input: "text-sm",
             }}
+            placeholder={t("command_palette.placeholder")}
+            startContent={
+              <Search className="text-muted-foreground" size={18} />
+            }
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
           />
 
           <div className="max-h-96 overflow-y-auto space-y-4">
@@ -394,16 +404,17 @@ export default function CommandPalette({
                 <div className="space-y-1">
                   {commands.map((command) => {
                     const isSelected = currentIndex === selectedIndex;
-                    const itemIndex = currentIndex++;
+
+                    currentIndex += 1;
 
                     return (
                       <Button
                         key={command.id}
-                        variant={isSelected ? "flat" : "light"}
                         className={`
                           w-full justify-start h-auto p-3 text-left
                           ${isSelected ? "bg-primary/10 border border-primary/20" : "hover:bg-accent/50"}
                         `}
+                        variant={isSelected ? "flat" : "light"}
                         onPress={() => {
                           command.action();
                           onClose();
@@ -447,7 +458,7 @@ export default function CommandPalette({
 
             {filteredCommands.length === 0 && (
               <div className="text-center py-8 text-muted-foreground">
-                <Search size={48} className="mx-auto mb-4 opacity-50" />
+                <Search className="mx-auto mb-4 opacity-50" size={48} />
                 <p className="text-sm">{t("command_palette.no_results")}</p>
                 <p className="text-xs">{t("command_palette.try_different")}</p>
               </div>

--- a/client/components/TimeWheelPicker.tsx
+++ b/client/components/TimeWheelPicker.tsx
@@ -25,7 +25,7 @@ interface TimeWheelPickerProps {
 }
 
 const TimeWheelPicker: React.FC<TimeWheelPickerProps> = ({
-  label = "Saat",
+  label = "Time",
   value = "",
   onChange,
   isRequired = false,
@@ -42,28 +42,37 @@ const TimeWheelPicker: React.FC<TimeWheelPickerProps> = ({
   const minuteRef = useRef<HTMLDivElement>(null);
 
   // Parse min and max times
-  const [minHour, minMinute] = min.split(":").map(Number);
-  const [maxHour, maxMinute] = max.split(":").map(Number);
+  const [minHour] = min.split(":").map(Number);
+  const [maxHour] = max.split(":").map(Number);
 
   // Generate hour and minute options
-  const hours = Array.from({ length: maxHour - minHour + 1 }, (_, i) => minHour + i);
+  const hours = Array.from(
+    { length: maxHour - minHour + 1 },
+    (_, i) => minHour + i,
+  );
   const minutes = Array.from({ length: 4 }, (_, i) => i * 15); // 0, 15, 30, 45
 
   // Initialize values from props
   useEffect(() => {
     if (value) {
       const [hour, minute] = value.split(":").map(Number);
+
       setSelectedHour(hour);
       setSelectedMinute(minute);
     }
   }, [value]);
 
   // Scroll to selected item
-  const scrollToSelected = (containerRef: React.RefObject<HTMLDivElement>, index: number) => {
+  const scrollToSelected = (
+    containerRef: React.RefObject<HTMLDivElement>,
+    index: number,
+  ) => {
     if (containerRef.current) {
       const container = containerRef.current;
       const itemHeight = 48; // Height of each item
-      const scrollTop = index * itemHeight - container.clientHeight / 2 + itemHeight / 2;
+      const scrollTop =
+        index * itemHeight - container.clientHeight / 2 + itemHeight / 2;
+
       container.scrollTo({ top: scrollTop, behavior: "smooth" });
     }
   };
@@ -72,8 +81,9 @@ const TimeWheelPicker: React.FC<TimeWheelPickerProps> = ({
   const handleOpen = () => {
     onOpen();
     setTimeout(() => {
-      const hourIndex = hours.findIndex(h => h === selectedHour);
-      const minuteIndex = minutes.findIndex(m => m === selectedMinute);
+      const hourIndex = hours.findIndex((h) => h === selectedHour);
+      const minuteIndex = minutes.findIndex((m) => m === selectedMinute);
+
       scrollToSelected(hourRef, hourIndex);
       scrollToSelected(minuteRef, minuteIndex);
     }, 100);
@@ -82,19 +92,22 @@ const TimeWheelPicker: React.FC<TimeWheelPickerProps> = ({
   // Handle wheel item click
   const handleHourClick = (hour: number) => {
     setSelectedHour(hour);
-    const hourIndex = hours.findIndex(h => h === hour);
+    const hourIndex = hours.findIndex((h) => h === hour);
+
     scrollToSelected(hourRef, hourIndex);
   };
 
   const handleMinuteClick = (minute: number) => {
     setSelectedMinute(minute);
-    const minuteIndex = minutes.findIndex(m => m === minute);
+    const minuteIndex = minutes.findIndex((m) => m === minute);
+
     scrollToSelected(minuteRef, minuteIndex);
   };
 
   // Confirm selection
   const handleConfirm = () => {
-    const timeString = `${selectedHour.toString().padStart(2, '0')}:${selectedMinute.toString().padStart(2, '0')}`;
+    const timeString = `${selectedHour.toString().padStart(2, "0")}:${selectedMinute.toString().padStart(2, "0")}`;
+
     onChange?.(timeString);
     onClose();
   };
@@ -105,39 +118,35 @@ const TimeWheelPicker: React.FC<TimeWheelPickerProps> = ({
   return (
     <>
       <Input
+        readOnly
+        className={`${className} cursor-pointer`}
+        classNames={{
+          input: ["cursor-pointer"],
+          inputWrapper: ["cursor-pointer"],
+        }}
+        description={description}
+        errorMessage={errorMessage}
+        isRequired={isRequired}
         label={label}
         value={displayValue}
         onClick={handleOpen}
-        readOnly
-        isRequired={isRequired}
-        errorMessage={errorMessage}
-        description={description}
-        className={`${className} cursor-pointer`}
-        classNames={{
-          input: [
-            "cursor-pointer",
-          ],
-          inputWrapper: [
-            "cursor-pointer",
-          ],
-        }}
       />
 
-      <Modal 
-        isOpen={isOpen} 
-        onClose={onClose}
-        size="sm"
-        placement="center"
+      <Modal
         classNames={{
           base: "bg-white dark:bg-gray-900",
           body: "py-6",
           header: "border-b border-gray-200 dark:border-gray-700",
           footer: "border-t border-gray-200 dark:border-gray-700",
         }}
+        isOpen={isOpen}
+        placement="center"
+        size="sm"
+        onClose={onClose}
       >
         <ModalContent>
           <ModalHeader className="flex flex-col gap-1">
-            <h3 className="text-lg font-semibold">Saat Seçin</h3>
+            <h3 className="text-lg font-semibold">Select Time</h3>
             <p className="text-sm text-gray-500">{description}</p>
           </ModalHeader>
           <ModalBody>
@@ -145,29 +154,30 @@ const TimeWheelPicker: React.FC<TimeWheelPickerProps> = ({
               {/* Hour Wheel */}
               <div className="flex flex-col items-center">
                 <div className="text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">
-                  Saat
+                  Hour
                 </div>
-                <div 
+                <div
                   ref={hourRef}
-                  className="h-48 w-16 overflow-y-auto scrollbar-hide relative"
+                  className="h-48 w-16 overflow-y-auto relative"
                   style={{
-                    scrollbarWidth: 'none',
-                    msOverflowStyle: 'none',
+                    scrollbarWidth: "none",
+                    msOverflowStyle: "none",
                   }}
                 >
                   <div className="py-20">
                     {hours.map((hour) => (
-                      <div
+                      <button
                         key={hour}
-                        onClick={() => handleHourClick(hour)}
-                        className={`h-12 flex items-center justify-center cursor-pointer transition-all duration-200 ${
+                        className={`h-12 w-full flex items-center justify-center cursor-pointer transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded-lg ${
                           hour === selectedHour
-                            ? "bg-blue-500 text-white rounded-lg scale-105 font-semibold"
-                            : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg"
+                            ? "bg-blue-500 text-white scale-105 font-semibold"
+                            : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
                         }`}
+                        type="button"
+                        onClick={() => handleHourClick(hour)}
                       >
-                        {hour.toString().padStart(2, '0')}
-                      </div>
+                        {hour.toString().padStart(2, "0")}
+                      </button>
                     ))}
                   </div>
                 </div>
@@ -181,29 +191,30 @@ const TimeWheelPicker: React.FC<TimeWheelPickerProps> = ({
               {/* Minute Wheel */}
               <div className="flex flex-col items-center">
                 <div className="text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">
-                  Dakika
+                  Minute
                 </div>
-                <div 
+                <div
                   ref={minuteRef}
-                  className="h-48 w-16 overflow-y-auto scrollbar-hide relative"
+                  className="h-48 w-16 overflow-y-auto relative"
                   style={{
-                    scrollbarWidth: 'none',
-                    msOverflowStyle: 'none',
+                    scrollbarWidth: "none",
+                    msOverflowStyle: "none",
                   }}
                 >
                   <div className="py-20">
                     {minutes.map((minute) => (
-                      <div
+                      <button
                         key={minute}
-                        onClick={() => handleMinuteClick(minute)}
-                        className={`h-12 flex items-center justify-center cursor-pointer transition-all duration-200 ${
+                        className={`h-12 w-full flex items-center justify-center cursor-pointer transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded-lg ${
                           minute === selectedMinute
-                            ? "bg-blue-500 text-white rounded-lg scale-105 font-semibold"
-                            : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg"
+                            ? "bg-blue-500 text-white scale-105 font-semibold"
+                            : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
                         }`}
+                        type="button"
+                        onClick={() => handleMinuteClick(minute)}
                       >
-                        {minute.toString().padStart(2, '0')}
-                      </div>
+                        {minute.toString().padStart(2, "0")}
+                      </button>
                     ))}
                   </div>
                 </div>
@@ -213,33 +224,21 @@ const TimeWheelPicker: React.FC<TimeWheelPickerProps> = ({
             {/* Selected Time Display */}
             <div className="mt-4 text-center">
               <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                {selectedHour.toString().padStart(2, '0')}:{selectedMinute.toString().padStart(2, '0')}
+                {selectedHour.toString().padStart(2, "0")}:
+                {selectedMinute.toString().padStart(2, "0")}
               </div>
             </div>
           </ModalBody>
           <ModalFooter>
-            <Button
-              color="danger"
-              variant="light"
-              onPress={onClose}
-            >
-              İptal
+            <Button color="danger" variant="light" onPress={onClose}>
+              Cancel
             </Button>
-            <Button
-              color="primary"
-              onPress={handleConfirm}
-            >
-              Seç
+            <Button color="primary" onPress={handleConfirm}>
+              Select
             </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>
-
-      <style jsx global>{`
-        .scrollbar-hide::-webkit-scrollbar {
-          display: none;
-        }
-      `}</style>
     </>
   );
 };

--- a/client/types/index.ts
+++ b/client/types/index.ts
@@ -274,6 +274,8 @@ export interface Surgery {
 // Complaint Types
 export interface Complaint {
   complaint_id: string;
+  _id?: string;
+  id?: string;
   patient_id: string;
   complaint_text: string;
   category: 'service' | 'billing' | 'medical' | 'facility' | 'staff' | 'other';


### PR DESCRIPTION
## Summary
- add focus handling and English-only command metadata to the dashboard command palette
- translate and harden patient/time picker components with accessible buttons and English messaging
- refresh dashboard settings/password UI with English copy, accessible slider labels, and updated complaint typing

## Testing
- `npm --prefix client run lint -- --quiet`
- `CI=1 npm --prefix client run build` *(fails: TypeScript complaints about existing dashboard modules; see console output)*

------
https://chatgpt.com/codex/tasks/task_b_68dfc4ac169c83229bb4c380d10837d8